### PR TITLE
Topic/psc release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A build tool for PureScript.
 
 ```sh
 $ npm install -g pulp
-$ pulp install --tag v0.6.2
+$ pulp install
 ```
 
 Alternatively, if you would like to manually install PureScript, the
@@ -47,9 +47,10 @@ it.
 * `pulp init` generates a project skeleton with a `bower.json` file
   and a simple example program.
 * `pulp install` installs a Purescript binary release into your
-  project's `node_modules/.bin`. The version to install must be
+  project's `node_modules/.bin`. The version to install may be
   specified by the `--tag` option. The option's value is the Github tag
-  of the release.
+  of the release. If this is not specified, the latest PureScript
+  version is used.
 * `pulp dep` does dependency management through Bower; essentially, it
   just passes you on to a locally installed version of `bower`. Thus,
   `pulp dep install foo --save` is the equivalent of `bower install

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ A build tool for PureScript.
 ## Installation
 
 ```sh
+$ npm install -g pulp
+$ pulp install --tag v0.6.2
+```
+
+Alternatively, if you would like to manually install PureScript, the
+following may be used.
+
+```sh
 $ cabal install purescript
 $ npm install -g pulp
 ```
@@ -38,6 +46,10 @@ it.
 
 * `pulp init` generates a project skeleton with a `bower.json` file
   and a simple example program.
+* `pulp install` installs a Purescript binary release into your
+  project's `node_modules/.bin`. The version to install must be
+  specified by the `--tag` option. The option's value is the Github tag
+  of the release.
 * `pulp dep` does dependency management through Bower; essentially, it
   just passes you on to a locally installed version of `bower`. Thus,
   `pulp dep install foo --save` is the equivalent of `bower install

--- a/exec.js
+++ b/exec.js
@@ -1,7 +1,11 @@
 var files = require("./files");
 var child = require("child_process");
 var glob = require("glob");
+var fs = require("fs");
+var path = require("path");
 var q = require("q");
+
+var bin = path.join('node_modules', '.bin');
 
 function exec(cmd, quiet, args, env, callback) {
   var output = q.defer();
@@ -44,11 +48,15 @@ function invokeCompiler(cmd, quiet, deps, args, env, callback) {
     if (err) {
       callback(err);
     } else {
-      exec(cmd, quiet, args.concat(deps), env, callback);
+      var local = path.join(bin, cmd);
+      fs.exists(local, function(exists) {
+        exec(exists ? local : cmd, quiet, args.concat(deps), env, callback);
+      });
     }
   });
 }
 
+module.exports.bin = bin;
 module.exports.exec = exec;
 module.exports.invokeCompiler = invokeCompiler;
 module.exports.psc = invokeCompiler.bind(null, "psc", true);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ var commands = {
     action: require("./init"),
     noProject: true
   },
+  "install": {
+    description: "Install PureScript binary release",
+    action: require("./install"),
+    noProject: true
+  },
   "dep": {
     description: "Invoke Bower for package management",
     action: require("./bower"),
@@ -119,6 +124,10 @@ if (!runNoParseCmd()) {
     "--skip-entry-point": {
       type: "boolean",
       description: "Don't add code to automatically invoke Main when browserifying."
+    },
+    "--tag": {
+      type: "string",
+      description: "For 'pulp install', specifies release tag for install."
     }
   }).validate(function(result) {
     if (result.help) {

--- a/install.js
+++ b/install.js
@@ -1,0 +1,5 @@
+var pscRelease = require("psc-release");
+
+module.exports = function(args, callback) {
+  pscRelease({tag: args.tag}, callback);
+};

--- a/install.js
+++ b/install.js
@@ -1,5 +1,11 @@
 var pscRelease = require("psc-release");
+var mkdirp = require("mkdirp");
+var exec = require("./exec");
 
 module.exports = function(args, callback) {
-  pscRelease({tag: args.tag}, callback);
+  mkdirp(exec.bin, function(e) {
+    if (e) callback(e);
+    else pscRelease({ tag: args.tag
+                    , bin: exec.bin }, callback);
+  });
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "concat-stream": "^1.4.6",
     "glob": "^4.0.2",
     "minimatch": "^1.0.0",
+    "mkdirp": "^0.5.0",
     "psc-release": "0.0.2",
     "q": "^1.0.1",
     "raptor-args": "^0.1.14-beta",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "concat-stream": "^1.4.6",
     "glob": "^4.0.2",
     "minimatch": "^1.0.0",
+    "psc-release": "0.0.1",
     "q": "^1.0.1",
     "raptor-args": "^0.1.14-beta",
     "string-stream": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "concat-stream": "^1.4.6",
     "glob": "^4.0.2",
     "minimatch": "^1.0.0",
-    "psc-release": "0.0.1",
+    "psc-release": "0.0.2",
     "q": "^1.0.1",
     "raptor-args": "^0.1.14-beta",
     "string-stream": "0.0.7",


### PR DESCRIPTION
PR pertaining to issue #13.

This does not come without caveats however. For one, `psc-release` relies on a file naming convention of the Github asset files. I am not sure if this is a same assumption to make. Perhaps @paf31 can chime in on this matter. Basically, I am referring to ethul/psc-release#2, and if it's safe to assume the mapping from platform name to PureScript asset filename.

Also, @bodil, I think the addition to the README here may need a bit of tweaking. If you think this PR is a good direction to go, perhaps it would be worth discussing the installation procedure that is described there.

In any case, this is more or less a first attempt. I am open to any suggestions, feedback, or comments.
