### PR TITLE
use existing environment variables

### DIFF
--- a/run.js
+++ b/run.js
@@ -2,6 +2,7 @@ var exec = require("./exec");
 var path = require("path");
 var log = require("./log");
 var files = require("./files");
+var extend = require('util')._extend;
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
@@ -11,9 +12,8 @@ module.exports = function(pro, args, callback) {
     var buildPath = path.resolve(args.buildPath);
     var mainPath = path.resolve(args, buildPath, "Main", "index.js");
     var entryPoint = args.main.replace("\\", "\\\\").replace("'", "\\'");
-    exec.exec("node", false, ["-e", "require('" + entryPoint + "').main()"], {
-      PATH: process.env.PATH,
-      NODE_PATH: buildPath + ":" + process.env.NODE_PATH
-    }, callback);
+    var env = extend({}, process.env);
+    env.NODE_PATH = buildPath + ":" + process.env.NODE_PATH;
+    exec.exec("node", false, ["-e", "require('" + entryPoint + "').main()"], env, callback);
   });
 };

--- a/run.js
+++ b/run.js
@@ -13,7 +13,7 @@ module.exports = function(pro, args, callback) {
     var mainPath = path.resolve(args, buildPath, "Main", "index.js");
     var entryPoint = args.main.replace("\\", "\\\\").replace("'", "\\'");
     var env = extend({}, process.env);
-    env.NODE_PATH = buildPath + ":" + process.env.NODE_PATH;
+    env.NODE_PATH = buildPath + path.delimiter + process.env.NODE_PATH;
     exec.exec("node", false, ["-e", "require('" + entryPoint + "').main()"], env, callback);
   });
 };


### PR DESCRIPTION
The way it is right now is that pulp overwrites all existing environment variables in the OS. This makes it impossible to spawn a node process when you are using something like [nodist](https://github.com/marcelklehr/nodist) (version manager for node) which is depending on other environment variables.

This fix uses existing environment variables and just extends them with the custom `NODE_PATH`

I've also changed `NODE_PATH`'s delimiter between paths to the platform specific one provided by node
