### PR TITLE
Added new options for controlling colors.

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -8,13 +8,13 @@ var fs = require("fs");
 var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
-  log("Compiling...");
+  log.message("Compiling...");
   exec.psc([files.src, files.deps], [
     "--module", args.main, "--main", args.main
   ], null, function(err, src) {
     if (err) return callback(err);
-    log("Compilation successful.");
-    log("Browserifying...");
+    log.message("Compilation successful.");
+    log.message("Browserifying...");
     var nodePath = process.env.NODE_PATH;
     var buildPath = path.resolve(args.buildPath);
     process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
@@ -31,7 +31,7 @@ function optimising(pro, args, callback) {
 function incremental(pro, args, callback) {
   build(pro, args, function(err) {
     if (err) return callback(err);
-    log("Browserifying...");
+    log.message("Browserifying...");
     var nodePath = process.env.NODE_PATH;
     var buildPath = path.resolve(args.buildPath);
     process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
@@ -54,12 +54,12 @@ function incremental(pro, args, callback) {
 }
 
 module.exports = function(pro, args, callback) {
-  log("Browserifying project in", process.cwd());
+  log.message("Browserifying project in", process.cwd());
   (args.optimise ? optimising : incremental)(pro, args, function(err) {
     if (err) {
       callback(err);
     } else {
-      log("Browserified.");
+      log.message("Browserified.");
       callback();
     }
   });

--- a/build.js
+++ b/build.js
@@ -3,10 +3,10 @@ var log = require("./log");
 var files = require("./files");
 
 module.exports = function(pro, args, callback) {
-  log("Building project in", process.cwd());
+  log.message("Building project in", process.cwd());
   exec.pscMake([files.src, files.deps], ["--output", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
-    log("Build successful.");
+    log.message("Build successful.");
     callback(null);
   });
 };

--- a/docs.js
+++ b/docs.js
@@ -5,7 +5,7 @@ var glob = require("glob");
 var fs = require("fs");
 
 module.exports = function(pro, args, callback) {
-  log("Generating documentation in", process.cwd());
+  log.message("Generating documentation in", process.cwd());
   files.src(function(err, files) {
     var c = child.spawn("psc-docs", files, {
       stdio: [process.stdin, "pipe", process.stderr]
@@ -13,7 +13,7 @@ module.exports = function(pro, args, callback) {
       if (code) {
         callback(new Error("Subcommand terminated with error code " + code), code);
       } else {
-        log("Documentation generated.");
+        log.message("Documentation generated.");
         callback(null, 0);
       }
     }).on("error", function(err) {

--- a/index.js
+++ b/index.js
@@ -114,7 +114,19 @@ if (!runNoParseCmd()) {
     },
     "--monochrome": {
       type: "boolean",
-      description: "Don't colourise log output"
+      description: "Don't colourise log output.  Overrides all color options."
+    },
+    "--message-color": {
+      type: "string",
+      description: "Set hex code of status message color."
+    },
+    "--error-color": {
+      type: "string",
+      description: "Set hex code of error message color."
+    },
+    "--color-line": {
+      type: "boolean",
+      description: "Color entire message line instead of just the leading asterisk."
     },
     "--skip-entry-point": {
       type: "boolean",
@@ -125,6 +137,15 @@ if (!runNoParseCmd()) {
       this.printUsage();
       printCommands();
       process.exit(0);
+    }
+    if (result.colorLine) {
+      log.fullLine(true);
+    }
+    if (result.messageColor) {
+      log.msgColor(result.messageColor);
+    }
+    if (result.errorColor) {
+      log.errColor(result.errorColor);
     }
     if (result.monochrome) {
       log.mono(true);

--- a/init.js
+++ b/init.js
@@ -36,7 +36,7 @@ var testFile = [
 
 function init(callback) {
   var name = path.basename(process.cwd());
-  log("Generating project skeleton in", process.cwd());
+  log.message("Generating project skeleton in", process.cwd());
   fs.writeFileSync(path.join(process.cwd(), "bower.json"), bowerFile(name), "utf-8");
   if (!fs.existsSync("src")) {
     fs.mkdirSync("src");

--- a/log.js
+++ b/log.js
@@ -3,17 +3,33 @@ var c = require("ansi")(process.stderr);
 var util = require("util");
 
 var mono = false;
+var fullLine = false;
 
 function log(severity) {
   var args = u.toArray(arguments).slice(1);
   if (mono) {
     c.write("* ");
   } else {
-    c[severity]().bold().write("*").reset().write(" ");
+    c.hex(severity).bold().write("*");
+    if (fullLine) {
+      c.resetBold().write(" ");
+    } else {
+      c.reset().write(" ");
+    }
   }
   console.error.apply(null, args);
+  if (fullLine) {
+    c.reset();
+  }
 }
 
-module.exports = log.bind(null, "green");
-module.exports.error = log.bind(null, "red");
+module.exports.message = log.bind(null, "4e9a06");
+module.exports.error = log.bind(null, "cc0000");
 module.exports.mono = function(flag) { mono = flag; };
+module.exports.fullLine = function(flag) { fullLine = flag; };
+module.exports.msgColor = function(msgColor) { 
+  module.exports.message = log.bind(null, msgColor);
+};
+module.exports.errColor = function(errColor) { 
+  module.exports.error = log.bind(null, errColor);
+};

--- a/run.js
+++ b/run.js
@@ -4,10 +4,10 @@ var log = require("./log");
 var files = require("./files");
 
 module.exports = function(pro, args, callback) {
-  log("Building project in", process.cwd());
+  log.message("Building project in", process.cwd());
   exec.pscMake([files.src, files.deps], ["--output", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
-    log("Build successful.");
+    log.message("Build successful.");
     var buildPath = path.resolve(args.buildPath);
     var mainPath = path.resolve(args, buildPath, "Main", "index.js");
     var entryPoint = args.main.replace("\\", "\\\\").replace("'", "\\'");

--- a/test.js
+++ b/test.js
@@ -4,10 +4,10 @@ var log = require("./log");
 var files = require("./files");
 
 module.exports = function(pro, args, callback) {
-  log("Building project in", process.cwd());
+  log.message("Building project in", process.cwd());
   exec.pscMake([files.src, files.test, files.deps], ["--output", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
-    log("Build successful. Running tests...");
+    log.message("Build successful. Running tests...");
     var buildPath = path.resolve(args.buildPath);
     var mainPath = path.resolve(args, buildPath, "Main", "index.js");
     exec.exec("node", false, ["-e", "require('Test.Main').main()"], {
@@ -15,7 +15,7 @@ module.exports = function(pro, args, callback) {
       NODE_PATH: buildPath + ":" + process.env.NODE_PATH
     }, function(err, rv) {
       if (err) return callback(err);
-      log("Tests OK.");
+      log.message("Tests OK.");
       callback();
     });
   });

--- a/watch.js
+++ b/watch.js
@@ -29,7 +29,7 @@ module.exports = function() {
   var p = child.fork(mod, args);
   var change = function() {
     p.kill("SIGTERM");
-    log("Source tree changed; restarting:");
+    log.message("Source tree changed; restarting:");
     p = child.fork(mod, args);
   };
   watch(["src/**/*", "test/**/*", "bower_components/**/*"], change);


### PR DESCRIPTION
This PR is in response to #18.  I added 3 color related options.  One controls the error message color, one the standard message color, and one controls whether the color is applied to the entire text line.  Option descriptions for monochrome and the new options were included/updated.  My implementation required changing `log()` to `log.message()` (I couldn't figure out any other way. JS novice here.)

Interesting note: even without setting any of the new options, the new implementation using hex colors corrected the problem I saw in my terminal under the solarized theme in which the message color looked grey instead of green.

So, it looks like the minimal number of changes required for my personally desired behavior was 2: use hex codes for colors and add an option for coloring the full text line.  The options controlling color weren't needed for my personal case because the default hex green and red are showing up correctly for me.
