### PR TITLE
Rename entry file from "main.js" to "index.js"

### DIFF
--- a/run.js
+++ b/run.js
@@ -16,7 +16,7 @@ module.exports = function(pro, args, callback) {
     var env = extend({}, process.env);
     env.NODE_PATH = buildPath + path.delimiter + process.env.NODE_PATH;
     var src = "require('" + entryPoint + "').main();\n";
-    var entryPath = path.join(buildPath, "main.js");
+    var entryPath = path.join(buildPath, "index.js");
     fs.writeFileSync(entryPath, src, "utf-8");
     exec.exec(
       "node", false, [entryPath].concat(args.remainder),


### PR DESCRIPTION
`main.js` clashes with the skeleton's default `Main` module - Node
will load `main.js`, rather than `Main/index.js` upon calling
`require('Main')`. By renaming from `main.js` to something else,
node will load the proper module.

Fixes #26
