### PR TITLE
start at version 0.1.0 with `pulp init`

### DIFF
--- a/init.js
+++ b/init.js
@@ -5,7 +5,7 @@ var fs = require("fs");
 function bowerFile(name) {
   return JSON.stringify({
     name: name,
-    version: "1.0.0",
+    version: "0.1.0",
     moduleType: ["node"],
     ignore: [
       "**/.*",


### PR DESCRIPTION
I think most people would expect version 1.0.0 to be released only when a project is considered mature-ish. How would you feel about putting the version in as "0.1.0" in the bower.json file during `pulp init` instead?
