### PR TITLE
Different javascript engines (node, iojs)

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ var commands = [
       args.option(
         "testRuntime", ["--runtime", "-r"], args.string,
         "Run test script using this command instead of Node."
+      ),
+      args.option(
+        "engine", ["--engine"], args.string,
+        "Run the Application on a different JavaScript engine (node, iojs)", "node"
       )
     ].concat([buildArgs[0]])
   ),
@@ -104,7 +108,12 @@ var commands = [
   args.command(
     "run", "Compile and run the project.", function() {
       return require("./run").apply(this, arguments);
-    }, buildArgs
+    }, [
+      args.option(
+        "engine", ["--engine"], args.string,
+        "Run the Application on a different JavaScript engine (node, iojs)", "node"
+      )
+    ].concat(buildArgs)
   ),
   args.command(
     "docs", "Generate project documentation.", function() {

--- a/run.js
+++ b/run.js
@@ -24,7 +24,7 @@ module.exports = function(pro, args, callback) {
         fs.close(info.fd, function(err) {
           if (err) return callback(err);
           exec.exec(
-            "node", false, [info.path].concat(args.remainder),
+            args.engine, false, [info.path].concat(args.remainder),
             env, callback
           );
         });

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ module.exports = function(pro, args, callback) {
         log("Build successful. Running tests...");
         var buildPath = path.resolve(args.buildPath);
         exec.exec(
-          "node", false,
+          args.engine, false,
           ["-e", "require('" + args.main + "').main()"].concat(args.remainder),
           {
             PATH: process.env.PATH,


### PR DESCRIPTION
- Added new argument to both run and test (--engine)
- Allowed the default --engine argument to be node (backwards
   compatible)
- Passes the engine value directly to the process exec so we don't have
   to keep updating pulp when a new node engine comes out (windows?!)
