### PR TITLE
`pulp get`, and `pulp gen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ it.
   PureScript's `psc-docs` command.
 * `pulp psci` launches a PureScript REPL using `psci` with the
   project's modules and dependencies installed.
+* `pulp get` a shortcut for `pulp dep install --save purescript-`. For example
+  `pulp get signal` is equivalent to `bower install --save purescript-signal`.
+  You may also pass a flag `--dev` to save as a development dependency via `--save-dev`.
+* `pulp gen` will automatically create `src` and `test` files for a given module, as well as
+  wire the new test file into `test/Main.purs`. For example in a fresh pulp project, running
+  `pulp gen Foo.Bar` will generate `src/Foo/Bar.purs`, and `test/Foo/Bar.purs`.
 
 ## Watch and restart
 

--- a/gen.js
+++ b/gen.js
@@ -37,14 +37,17 @@ function write(file, trail, moduleName){
 
   function writeDir(dirName){
     var p = prependBase(dirName);
-    console.log("p",p);
     if(!fs.existsSync(p)){
       console.log(p);
       fs.mkdirSync(p);
       console.log("no way");
       trail.push(dirName);
+    }else{
+      console.log("already dir", p);
     }
   }
+
+  writeDir("");
 
   for(var i = 0; i < modulePath.length; i++){
     var current = modulePath[i];

--- a/gen.js
+++ b/gen.js
@@ -1,0 +1,64 @@
+var log = require("./log");
+var path = require("path");
+var fs = require("fs");
+
+function src(moduleName){
+  return "module " + moduleName + " where";
+}
+
+function test(moduleName){
+  return ["module Test." + moduleName + " where",
+  "",
+  "import " + moduleName,
+  "import Debug.Trace",
+  "",
+  "main = do",
+  "  trace \"Write tests for " + moduleName + "\""
+  ].join("\n") + "\n";
+}
+
+function write(file, trail, moduleName){
+  var modulePath = moduleName.split(".");
+
+  function prependBase(x){
+    return path.join.apply(this, [process.cwd()].concat(trail).concat([x]));
+  }
+
+  function writeFile(fileName){
+    var f = prependBase(fileName + ".purs");
+
+    if(fs.existsSync(f)){
+      console.log("file already exists : " + f );
+    }else{
+      console.log("writing file : " + f );
+      fs.writeFileSync(f, file(moduleName), "utf-8");
+    }
+  }
+
+  function writeDir(dirName){
+    var p = prependBase(dirName);
+    console.log("p",p);
+    if(!fs.existsSync(p)){
+      console.log(p);
+      fs.mkdirSync(p);
+      console.log("no way");
+      trail.push(dirName);
+    }
+  }
+
+  for(var i = 0; i < modulePath.length; i++){
+    var current = modulePath[i];
+    if(i === modulePath.length - 1){
+      writeFile(current);
+    }else{
+      writeDir(current);
+    }
+  }
+
+}
+
+module.exports = function(pro, args, callback) {
+  write(src, ["src"], args.remainder[0]);
+  write(test, ["test"], args.remainder[0]);
+  callback();
+}

--- a/gen.js
+++ b/gen.js
@@ -13,7 +13,7 @@ function test(moduleName){
   "import Debug.Trace",
   "",
   "main = do",
-  "  trace \"Write tests for " + moduleName + "\""
+  "  trace \"You should add tests for " + moduleName + "\""
   ].join("\n") + "\n";
 }
 

--- a/gen.js
+++ b/gen.js
@@ -17,8 +17,14 @@ function test(moduleName){
   ].join("\n") + "\n";
 }
 
+function capitalise(string) {
+    if(string){
+      return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+    }else{ return ""; }
+}
+
 function write(file, trail, moduleName){
-  var modulePath = moduleName.split(".");
+  var modulePath = moduleName.split(".").map(capitalise);
 
   function prependBase(x){
     return path.join.apply(this, [process.cwd()].concat(trail).concat([x]));
@@ -26,25 +32,20 @@ function write(file, trail, moduleName){
 
   function writeFile(fileName){
     var f = prependBase(fileName + ".purs");
-
     if(fs.existsSync(f)){
-      console.log("file already exists : " + f );
+      console.log("file already exists : " + f + "\n leaving it be." );
     }else{
       console.log("writing file : " + f );
-      fs.writeFileSync(f, file(moduleName), "utf-8");
+      fs.writeFileSync(f, file(modulePath.join(".")), "utf-8");
     }
   }
 
   function writeDir(dirName){
     var p = prependBase(dirName);
     if(!fs.existsSync(p)){
-      console.log(p);
       fs.mkdirSync(p);
-      console.log("no way");
-      trail.push(dirName);
-    }else{
-      console.log("already dir", p);
     }
+    trail.push(dirName);
   }
 
   writeDir("");
@@ -61,7 +62,7 @@ function write(file, trail, moduleName){
 }
 
 module.exports = function(pro, args, callback) {
-  write(src, ["src"], args.remainder[0]);
+  write(src,  ["src"],  args.remainder[0]);
   write(test, ["test"], args.remainder[0]);
   callback();
 }

--- a/gen.js
+++ b/gen.js
@@ -61,8 +61,16 @@ function write(file, trail, moduleName){
 
 }
 
+function addToMain(moduleName){
+  moduleName = moduleName.split(".").map(capitalise).join(".");
+  var p = path.join(process.cwd(), "test/Main.purs");
+  console.log("adding to ", p);
+  fs.appendFileSync(p, "  Test." + moduleName + ".main\n");
+}
+
 module.exports = function(pro, args, callback) {
   write(src,  ["src"],  args.remainder[0]);
   write(test, ["test"], args.remainder[0]);
+  addToMain(args.remainder[0]);
   callback();
 }

--- a/gen.js
+++ b/gen.js
@@ -23,17 +23,17 @@ function capitalise(string) {
     }else{ return ""; }
 }
 
+function prependBase(trail, x){
+  return path.join.apply(this, [process.cwd()].concat(trail).concat([x]));
+}
+
 function write(file, trail, moduleName){
   var modulePath = moduleName.split(".").map(capitalise);
 
-  function prependBase(x){
-    return path.join.apply(this, [process.cwd()].concat(trail).concat([x]));
-  }
-
   function writeFile(fileName){
-    var f = prependBase(fileName + ".purs");
+    var f = prependBase(trail, fileName + ".purs");
     if(fs.existsSync(f)){
-      console.log("file already exists : " + f + "\n leaving it be." );
+      console.log("file already exists : " + f + "\nleaving it be." );
     }else{
       console.log("writing file : " + f );
       fs.writeFileSync(f, file(modulePath.join(".")), "utf-8");
@@ -41,7 +41,7 @@ function write(file, trail, moduleName){
   }
 
   function writeDir(dirName){
-    var p = prependBase(dirName);
+    var p = prependBase(trail, dirName);
     if(!fs.existsSync(p)){
       fs.mkdirSync(p);
     }

--- a/index.js
+++ b/index.js
@@ -129,8 +129,8 @@ var commands = [
   args.command(
     "get", "Shortcut for pulp dep install --save purescript-",
     function(pro, ar, callback) {
-      dev = ar.dev ? "-dev" : "";
-      ar.remainder = ["install", "--save" + dev, "purescript-" + ar.remainder[0]];
+      ar.remainder = ["install", "--save" + (ar.dev ? "-dev" : "")]
+        .concat( ar.remainder.map(function(x){ return "purescript-" + x; }) );
       return require("./bower").apply(this, [pro, ar, callback]);
     }, [
       args.option(
@@ -138,6 +138,12 @@ var commands = [
         "save as development dependency"
       )
     ]
+  ),
+  args.command(
+    "gen", "produce a new purescript module and test file",
+    function(){
+      return require("./gen").apply(this, arguments)
+    }
   )
 ];
 

--- a/index.js
+++ b/index.js
@@ -125,6 +125,19 @@ var commands = [
     function() {
       return require("./psci").apply(this, arguments);
     }
+  ),
+  args.command(
+    "get", "Shortcut for pulp dep install --save purescript-",
+    function(pro, ar, callback) {
+      dev = ar.dev ? "-dev" : "";
+      ar.remainder = ["install", "--save" + dev, "purescript-" + ar.remainder[0]];
+      return require("./bower").apply(this, [pro, ar, callback]);
+    }, [
+      args.option(
+        "dev", ["--dev"], args.flag,
+        "save as development dependency"
+      )
+    ]
   )
 ];
 


### PR DESCRIPTION
I added 2 commands.
- `pulp get` a shortcut for `pulp dep install --save purescript-`. For example
  `pulp get signal` is equivalent to `bower install --save purescript-signal`.
  You may also pass a flag `--dev` to save as a development dependency via `--save-dev`.
- `pulp gen` will automatically create `src` and `test` files for a given module, as well as
  wire the new test file into `test/Main.purs`. For example in a fresh pulp project, running
  `pulp gen Foo.Bar` will generate `src/Foo/Bar.purs`, and `test/Foo/Bar.purs`.
