### PR TITLE
Update for 0.7

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -9,7 +9,7 @@ var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
   log("Compiling...");
-  exec.psc([files.src, files.deps], [
+  exec.psc([files.src, files.deps], [files.srcForeign, files.depsForeign], [
     "--module=" + args.main, "--main=" + args.main
   ].concat(args.remainder), null, function(err, src) {
     if (err) return callback(err);

--- a/build.js
+++ b/build.js
@@ -6,20 +6,25 @@ var fs = require("fs");
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
   if (args.optimise) {
-    exec.psc([files.src, files.deps], [
-      "--module=" + args.main, "--main=" + args.main
-    ].concat(args.remainder), null, function(err, src) {
-      if (err) return callback(err);
-      var out = args.to ? fs.createWriteStream(args.to) : process.stdout;
-      out.write(src, "utf-8", function(err) {
+    exec.psc(
+      [files.src, files.deps], 
+      [files.srcForeign, files.depsForeign], 
+      [
+        "--module=" + args.main, "--main=" + args.main
+      ].concat(args.remainder), null, function(err, src) {
         if (err) return callback(err);
-        log("Build successful.");
-        callback(null);
+        var out = args.to ? fs.createWriteStream(args.to) : process.stdout;
+        out.write(src, "utf-8", function(err) {
+          if (err) return callback(err);
+          log("Build successful.");
+          callback(null);
+        });
       });
-    });
   } else {
     exec.pscMake(
-      [files.src, files.deps], ["-o", args.buildPath].concat(args.remainder),
+      [files.src, files.deps], 
+      [files.srcForeign, files.depsForeign], 
+      ["-o", args.buildPath].concat(args.remainder),
       null, function(err, rv) {
         if (err) return callback(err);
         log("Build successful.");

--- a/exec.js
+++ b/exec.js
@@ -39,12 +39,22 @@ function exec(cmd, quiet, args, env, callback) {
   }
 }
 
-function invokeCompiler(cmd, quiet, deps, args, env, callback) {
+function invokeCompiler(cmd, quiet, deps, ffi, args, env, callback) {
   files.resolve(deps, function(err, deps) {
     if (err) {
       callback(err);
     } else {
-      exec(cmd, quiet, args.concat(deps), env, callback);
+      files.resolve(ffi, function(err, ffi) {
+        if (err) {
+          callback(err);
+        } else {
+          var allArgs = args.concat(deps).concat([].concat.apply([], ffi.map(function(path) {
+            return ["--ffi", path];
+          })));
+
+          exec(cmd, quiet, allArgs, env, callback);
+        }
+      });
     }
   });
 }

--- a/files.js
+++ b/files.js
@@ -5,15 +5,30 @@ function deps(callback) {
 }
 module.exports.deps = deps;
 
+function depsForeign(callback) {
+  glob("bower_components/*/src/**/*.js", {}, callback);
+}
+module.exports.depsForeign = depsForeign;
+
 function src(callback) {
   glob("src/**/*.purs", {}, callback);
 }
 module.exports.src = src;
 
+function srcForeign(callback) {
+  glob("src/**/*.js", {}, callback);
+}
+module.exports.srcForeign = srcForeign;
+
 function test(callback) {
   glob("test/**/*.purs", {}, callback);
 }
 module.exports.test = test;
+
+function testForeign(callback) {
+  glob("test/**/*.js", {}, callback);
+}
+module.exports.testForeign = testForeign;
 
 function resolve(fns, callback) {
   function it(acc, fns, callback) {

--- a/init.js
+++ b/init.js
@@ -19,19 +19,19 @@ function bowerFile(name) {
 var mainFile = [
   "module Main where",
   "",
-  "import Debug.Trace",
+  "import Control.Monad.Eff.Console",
   "",
   "main = do",
-  "  trace \"Hello sailor!\""
+  "  log \"Hello sailor!\""
 ].join("\n") + "\n";
 
 var testFile = [
   "module Test.Main where",
   "",
-  "import Debug.Trace",
+  "import Control.Monad.Eff.Console",
   "",
   "main = do",
-  "  trace \"You should add some tests.\""
+  "  log \"You should add some tests.\""
 ].join("\n") + "\n";
 
 function init(callback) {

--- a/run.js
+++ b/run.js
@@ -8,7 +8,7 @@ var temp = require("temp").track();
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  exec.pscMake([files.src, files.deps], ["-o", args.buildPath], null, function(err, rv) {
+  exec.pscMake([files.src, files.deps], [files.srcForeign, files.depsForeign], ["-o", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
     log("Build successful.");
     var buildPath = path.resolve(args.buildPath);

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ module.exports = function(pro, args, callback) {
     if (!args.to) args.to = "./output/test.js";
     exec.psc(
       [files.src, files.test, files.deps],
+      [files.srcForeign, files.testForeign, files.depsForeign],
       ["-o", args.to, "--main=" + args.main],
       null, function(err, rv) {
         if (err) return callback(err);
@@ -27,6 +28,7 @@ module.exports = function(pro, args, callback) {
   } else {
     exec.pscMake(
       [files.src, files.test, files.deps],
+      [files.srcForeign, files.testForeign, files.depsForeign],
       ["-o", args.buildPath], null, function(err, rv) {
         if (err) return callback(err);
         log("Build successful. Running tests...");


### PR DESCRIPTION
This shouldn't break anything for `0.6.*` as long as people don't have `*.js` files in their `src` or `test` directories.

We might want to consider running `dep i purescript-console` during `pulp init` too. What do you think?
