### PR TITLE
Run bower update on init

### DIFF
--- a/bower.js
+++ b/bower.js
@@ -1,12 +1,20 @@
 var path = require("path");
 var exec = require("./exec").exec;
 
-module.exports = function(pro, args, callback) {
-  var bowerArgs = args.remainder;
-  var executable = "bower";
-  if (process.platform == "win32") {
-  	executable += ".cmd";
-  }
-  exec(path.join(__dirname, "node_modules", ".bin", executable), false,
-       bowerArgs, process.env, callback);
-};
+module.exports = (function() {
+  var exp = function(pro, args, callback) {
+    var bowerArgs = args.remainder;
+    this.launchBower(bowerArgs, callback);
+  };
+
+  exp.launchBower = function(bowerArgs, callback) {
+    var executable = "bower";
+    if (process.platform == "win32") {
+      executable += ".cmd";
+    }
+    exec(path.join(__dirname, "node_modules", ".bin", executable), false,
+      bowerArgs, process.env, callback);
+  };
+
+  return exp;
+})();

--- a/init.js
+++ b/init.js
@@ -1,6 +1,7 @@
 var log = require("./log");
 var path = require("path");
 var fs = require("fs");
+var bower = require("./bower");
 
 function bowerFile(name) {
   return JSON.stringify({
@@ -12,7 +13,10 @@ function bowerFile(name) {
       "node_modules",
       "bower_components",
       "output"
-    ]
+    ],
+    dependencies: {
+      "purescript-console": "^0.1.0"
+    }
   }, null, 2) + "\n";
 }
 
@@ -46,7 +50,7 @@ function init(callback) {
     fs.mkdirSync("test");
   }
   fs.writeFileSync(path.join(process.cwd(), "test", "Main.purs"), testFile, "utf-8");
-  callback();
+  bower.launchBower(["update"], callback);
 }
 
 module.exports = function(args, callback) {


### PR DESCRIPTION
Adds `purescript-console` to the default dependencies in `bower.json`, and runs `bower update` on `init` to download it.
