### PR TITLE
Pulp now respects bower's settings for components directory

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,31 +5,32 @@ var fs = require("fs");
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  if (args.optimise) {
-    exec.psc(
-      [files.src, files.deps], 
-      [files.srcForeign, files.depsForeign], 
-      [
-        "--module=" + args.main, "--main=" + args.main
-      ].concat(args.remainder), null, function(err, src) {
-        if (err) return callback(err);
-        var out = args.to ? fs.createWriteStream(args.to) : process.stdout;
-        out.write(src, "utf-8", function(err) {
-          if (err) return callback(err);
-          log("Build successful.");
-          callback(null);
-        });
-      });
-  } else {
-    exec.pscMake(
-      [files.src, files.deps], 
-      [files.srcForeign, files.depsForeign], 
-      ["-o", args.buildPath].concat(args.remainder),
-      null, function(err, rv) {
-        if (err) return callback(err);
-        log("Build successful.");
+  
+  exec.psc(
+    [files.src, files.deps], 
+    [files.srcForeign, files.depsForeign], 
+    ["-o", args.buildPath].concat(args.remainder),
+    null, function(err, rv) {
+      if (err) return callback(err);
+      log("Build successful.");
+      if (args.optimise) {
+        log("Bundling Javascript...");
+        exec.pscBundle(
+          [files.outputModules(args.buildPath)], 
+          [
+            "--module=" + args.main, "--main=" + args.main
+          ].concat(args.remainder), null, function(err, src) {
+            if (err) return callback(err);
+            var out = args.to ? fs.createWriteStream(args.to) : process.stdout;
+            out.write(src, "utf-8", function(err) {
+              if (err) return callback(err);
+              log("Bundled.");
+              callback(null);
+            });
+          });
+      } else {
         callback(null);
       }
-    );
-  }
+    }
+  );
 };

--- a/exec.js
+++ b/exec.js
@@ -39,7 +39,7 @@ function exec(cmd, quiet, args, env, callback) {
   }
 }
 
-function invokeCompiler(cmd, quiet, deps, ffi, args, env, callback) {
+module.exports.psc = function(deps, ffi, args, env, callback) {
   files.resolve(deps, function(err, deps) {
     if (err) {
       callback(err);
@@ -52,14 +52,23 @@ function invokeCompiler(cmd, quiet, deps, ffi, args, env, callback) {
             return ["--ffi", path];
           })));
 
-          exec(cmd, quiet, allArgs, env, callback);
+          exec("psc", true, allArgs, env, callback);
         }
       });
     }
   });
-}
+};
+
+module.exports.pscBundle = function(dir, args, env, callback) {
+  files.resolve(dir, function(err, deps) {
+    if (err) {
+      callback(err);
+    } else {
+      var allArgs = args.concat(deps);
+
+      exec("psc-bundle", true, allArgs, env, callback);
+    }
+  });
+};
 
 module.exports.exec = exec;
-module.exports.invokeCompiler = invokeCompiler;
-module.exports.psc = invokeCompiler.bind(null, "psc", true);
-module.exports.pscMake = invokeCompiler.bind(null, "psc-make", true);

--- a/files.js
+++ b/files.js
@@ -49,6 +49,13 @@ function testForeign(callback) {
 }
 module.exports.testForeign = testForeign;
 
+function outputModules(buildPath) {
+  return function(callback) {
+    glob(buildPath + "/*/@(index.js|foreign.js)", {}, callback);
+  };
+}
+module.exports.outputModules = outputModules;
+
 function resolve(fns, callback) {
   function it(acc, fns, callback) {
     if (!fns.length) {

--- a/files.js
+++ b/files.js
@@ -1,12 +1,31 @@
 var glob = require("glob");
+var fs = require("fs");
+
+function readJson(fn) {
+  try {
+    return JSON.parse(fs.readFileSync(fn).toString());
+  } catch (e) {
+    return {};
+  }
+}
 
 function deps(callback) {
-  glob("bower_components/purescript-*/src/**/*.purs", {}, callback);
+  var bowerrc = readJson(".bowerrc");
+  if (bowerrc.directory) {
+    glob(bowerrc.directory + "/purescript-*/src/**/*.purs", {}, callback);
+  } else {
+    glob("bower_components/purescript-*/src/**/*.purs", {}, callback);
+  }
 }
 module.exports.deps = deps;
 
 function depsForeign(callback) {
-  glob("bower_components/purescript-*/src/**/*.js", {}, callback);
+  var bowerrc = readJson(".bowerrc");
+  if (bowerrc.directory) {
+    glob(bowerrc.directory + "/purescript-*/src/**/*.js", {}, callback);
+  } else {
+    glob("bower_components/purescript-*/src/**/*.js", {}, callback);
+  }
 }
 module.exports.depsForeign = depsForeign;
 

--- a/run.js
+++ b/run.js
@@ -8,7 +8,7 @@ var temp = require("temp").track();
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  exec.pscMake([files.src, files.deps], [files.srcForeign, files.depsForeign], ["-o", args.buildPath], null, function(err, rv) {
+  exec.psc([files.src, files.deps], [files.srcForeign, files.depsForeign], ["-o", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
     log("Build successful.");
     var buildPath = path.resolve(args.buildPath);

--- a/test.js
+++ b/test.js
@@ -10,29 +10,31 @@ module.exports = function(pro, args, callback) {
     log("Tests OK.");
     callback();
   };
-  if (args.testRuntime) {
-    if (!args.to) args.to = "./output/test.js";
-    exec.psc(
-      [files.src, files.test, files.deps],
-      [files.srcForeign, files.testForeign, files.depsForeign],
-      ["-o", args.to, "--main=" + args.main],
-      null, function(err, rv) {
-        if (err) return callback(err);
-        log("Build successful. Running tests...");
-        exec.exec(
-          args.testRuntime, false, [args.to].concat(args.remainder),
-          process.env, done
+  
+  exec.psc(
+    [files.src, files.test, files.deps],
+    [files.srcForeign, files.testForeign, files.depsForeign],
+    ["-o", args.buildPath], null, function(err, rv) {
+      if (err) return callback(err);
+      
+      if (args.testRuntime) {
+        if (!args.to) args.to = "./output/test.js";
+        log("Build successful. Bundling Javascript...");
+        exec.pscBundle(
+          [files.outputModules(args.buildPath)],
+          ["-o", args.to, "--main=" + args.main],
+          null, function(err, rv) {
+            if (err) return callback(err);
+            log("Running tests...");
+            exec.exec(
+              args.testRuntime, false, [args.to].concat(args.remainder),
+              process.env, done
+            );
+          }
         );
-      }
-    );
-  } else {
-    exec.pscMake(
-      [files.src, files.test, files.deps],
-      [files.srcForeign, files.testForeign, files.depsForeign],
-      ["-o", args.buildPath], null, function(err, rv) {
-        if (err) return callback(err);
-        log("Build successful. Running tests...");
+      } else {
         var buildPath = path.resolve(args.buildPath);
+        log("Build successful. Running tests...");
         exec.exec(
           "node", false,
           ["-e", "require('" + args.main + "').main()"].concat(args.remainder),
@@ -42,6 +44,6 @@ module.exports = function(pro, args, callback) {
           }, done
         );
       }
-    );
-  }
+    }
+  );
 };

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ module.exports = function(pro, args, callback) {
         log("Build successful. Bundling Javascript...");
         exec.pscBundle(
           [files.outputModules(args.buildPath)],
-          ["-o", args.to, "--main=" + args.main],
+          ["-o", args.to, "--module", args.main, "--main", args.main],
           null, function(err, rv) {
             if (err) return callback(err);
             log("Running tests...");


### PR DESCRIPTION
This patch enables Pulp to build projects even if Bower was configured to put `bower_components` somewhere else instead of project's root. 

Currently only a local `.bowerrc` file is respected. It is possible to read Bower's configuration from other places too, but imho it makes sense to respect only explicit local configuration, because Bower can be configured using ephemeral sources like env vars or command line options, which can not be restored afterwards.

So, to instruct Bower where to store downloaded components so that Pulp would respect that too one have to add a `.bowerrc` file into a project's root with content like this:

``` json
{
  "directory": "../bower_components"
}
```
