### PR TITLE
Fix bower invocation

### DIFF
--- a/bower.js
+++ b/bower.js
@@ -4,7 +4,7 @@ var exec = require("./exec").exec;
 module.exports = (function() {
   var exp = function(pro, args, callback) {
     var bowerArgs = args.remainder;
-    this.launchBower(bowerArgs, callback);
+    exp.launchBower(bowerArgs, callback);
   };
 
   exp.launchBower = function(bowerArgs, callback) {


### PR DESCRIPTION
A bad `this` reference was causing `pulp dep` to fail with:

```
    this.launchBower(bowerArgs, callback);
         ^
TypeError: Object #<Object> has no method 'launchBower'
```
