### PR TITLE
Use globs directly with purescript commands, and look for .cmd versions on Windows

### DIFF
--- a/bower.js
+++ b/bower.js
@@ -9,9 +9,6 @@ module.exports = (function() {
 
   exp.launchBower = function(bowerArgs, callback) {
     var executable = "bower";
-    if (process.platform == "win32") {
-      executable += ".cmd";
-    }
     exec(path.join(__dirname, "node_modules", ".bin", executable), false,
       bowerArgs, process.env, callback);
   };

--- a/browserify.js
+++ b/browserify.js
@@ -9,7 +9,7 @@ var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
   log("Compiling...");
-  exec.psc([files.src, files.deps], [files.srcForeign, files.depsForeign], [
+  exec.psc([files.srcGlob, files.depsGlob], files.ffiGlobs, [
     "--module=" + args.main, "--main=" + args.main
   ].concat(args.remainder), null, function(err, src) {
     if (err) return callback(err);

--- a/build.js
+++ b/build.js
@@ -7,8 +7,8 @@ module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
   
   exec.psc(
-    [files.src, files.deps], 
-    [files.srcForeign, files.depsForeign], 
+    [files.srcGlob, files.depsGlob],
+    files.ffiGlobs,
     ["-o", args.buildPath].concat(args.remainder),
     null, function(err, rv) {
       if (err) return callback(err);

--- a/docs.js
+++ b/docs.js
@@ -1,43 +1,34 @@
 var log = require("./log");
 var files = require("./files");
-var child = require("child_process");
-var glob = require("glob");
-var fs = require("fs");
+var exec = require("./exec");
 
 module.exports = function(pro, args, callback) {
   log("Generating documentation in", process.cwd());
-  var src = [files.src, files.deps];
+  var src = [files.srcGlob, files.depsGlob];
   var gen = [files.src];
   if (args.withTests) {
-    src.push(files.test);
+    src.push(files.testGlob);
     gen.push(files.test)
   }
-  files.resolve(src, function(err, srcFiles) {
-    files.resolve(gen, function(err, genFiles) {
-      var docgen = [].concat.apply([], genFiles.map(function(path) {
-        var moduleName = path.match("([A-Z][^\/\.]*(\/|\.))+");
-        var docPath = path.replace(/^(src|test)/, "docs").replace(/.purs$/, ".md");
-        if (moduleName && moduleName[0]) {
-          return ["--docgen", moduleName[0].replace(/\.$/, "").replace(/(\/|\\)/g, ".") + ":" + docPath]; 
-        } else {
-          log("Unable to generate documentation for " + path + ". Please make sure your module names are consistent with your file paths.");
-          return [];
-        }
-      }));
-      child.spawn("psc-docs", args.remainder.concat(srcFiles).concat(docgen), {
-        stdio: [process.stdin, "pipe", process.stderr]
-      }).on("exit", function(code, signal) {
-        if (code) {
-          callback(new Error("Subcommand terminated with error code " + code), code);
-        } else {
-          log("Documentation generated.");
-          callback(null, 0);
-        }
-      }).on("error", function(err) {
-        if (err.code === "ENOENT") {
-          callback(new Error("`psc-docs` executable not found."));
-        }
-      });
-    });
+  files.resolve(gen, function(err, genFiles) {
+    var docgen = [].concat.apply([], genFiles.map(function(path) {
+      var moduleName = path.match("([A-Z][^\/\.]*(\/|\.))+");
+      var docPath = path.replace(/^(src|test)/, "docs").replace(/.purs$/, ".md");
+      if (moduleName && moduleName[0]) {
+        return ["--docgen", moduleName[0].replace(/\.$/, "").replace(/(\/|\\)/g, ".") + ":" + docPath];
+      } else {
+        log("Unable to generate documentation for " + path + ". Please make sure your module names are consistent with your file paths.");
+        return [];
+      }
+    }));
+    exec.exec(
+      "psc-docs", true, args.remainder.concat(src).concat(docgen),
+      null, function(err, code) {
+        if(err) return callback(err, code);
+        if(code) return callback(new Error("Subcommand terminated with error code " + code), code);
+        log("Documentation generated.");
+        callback(null, 0);
+      }
+    );
   });
 };

--- a/exec.js
+++ b/exec.js
@@ -50,23 +50,10 @@ function exec(cmd, quiet, args, env, callback) {
 }
 
 module.exports.psc = function(deps, ffi, args, env, callback) {
-  files.resolve(deps, function(err, deps) {
-    if (err) {
-      callback(err);
-    } else {
-      files.resolve(ffi, function(err, ffi) {
-        if (err) {
-          callback(err);
-        } else {
-          var allArgs = args.concat(deps).concat([].concat.apply([], ffi.map(function(path) {
-            return ["--ffi", path];
-          })));
-
-          exec("psc", true, allArgs, env, callback);
-        }
-      });
-    }
-  });
+  var allArgs = args.concat(deps).concat([].concat.apply([], ffi.map(function(path) {
+    return ["--ffi", path];
+  })));
+  exec("psc", true, allArgs, env, callback);
 };
 
 module.exports.pscBundle = function(dir, args, env, callback) {

--- a/exec.js
+++ b/exec.js
@@ -28,7 +28,18 @@ function exec(cmd, quiet, args, env, callback) {
     }
   }).on("error", function(err) {
     if (err.code === "ENOENT") {
-      callback(new Error("`" + cmd + "` executable not found."));
+      // On Windows: if executable wasn't found, try adding .cmd
+      if (process.platform == "win32") {
+        if (!cmd.match(/\.cmd$/i)) {
+          exec(cmd + ".cmd", quiet, args, env, callback)
+        } else {
+          var bareCmd = cmd.substr(0, cmd.length - 4)
+          callback(new Error("`" + bareCmd + "` executable not found. (nor `" + cmd + "`)"));
+        }
+      }
+      else {
+        callback(new Error("`" + cmd + "` executable not found."));
+      }
     }
   });
   if (quiet) {

--- a/files.js
+++ b/files.js
@@ -1,5 +1,7 @@
 var glob = require("glob");
 var fs = require("fs");
+var path = require("path");
+
 
 function readJson(fn) {
   try {
@@ -8,6 +10,13 @@ function readJson(fn) {
     return {};
   }
 }
+
+var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*/");
+
+exports.srcGlob = "src/**/*.purs";
+exports.depsGlob = bowerDirs + exports.srcGlob;
+exports.testGlob = "test/**/*.purs";
+exports.ffiGlobs = ["src/**/*.js", bowerDirs + "src/**/*.js", "test/**/*.js"];
 
 function deps(callback) {
   var bowerrc = readJson(".bowerrc");

--- a/psci.js
+++ b/psci.js
@@ -1,7 +1,7 @@
 var log = require("./log");
 var files = require("./files");
+var exec = require("./exec");
 var fs = require("fs");
-var child = require("child_process");
 
 function updateConfig(callback) {
   fs.readFile(".psci", function(err, data) {
@@ -33,10 +33,6 @@ module.exports = function(pro, args, callback) {
     if (err) {
       return callback(err);
     }
-    child.spawn("psci", args.remainder, {
-      stdio: "inherit"
-    }).on("exit", function(code, signal) {
-      callback();
-    });
+    exec.exec("psci", false, args.remainder, null, callback);
   });
 };

--- a/run.js
+++ b/run.js
@@ -8,7 +8,7 @@ var temp = require("temp").track();
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  exec.psc([files.src, files.deps], [files.srcForeign, files.depsForeign], ["-o", args.buildPath], null, function(err, rv) {
+  exec.psc([files.srcGlob, files.depsGlob], files.ffiGlobs, ["-o", args.buildPath], null, function(err, rv) {
     if (err) return callback(err);
     log("Build successful.");
     var buildPath = path.resolve(args.buildPath);

--- a/test.js
+++ b/test.js
@@ -12,8 +12,8 @@ module.exports = function(pro, args, callback) {
   };
   
   exec.psc(
-    [files.src, files.test, files.deps],
-    [files.srcForeign, files.testForeign, files.depsForeign],
+    [files.srcGlob, files.testGlob, files.depsGlob],
+    files.ffiGlobs,
     ["-o", args.buildPath], null, function(err, rv) {
       if (err) return callback(err);
       

--- a/validate.js
+++ b/validate.js
@@ -4,6 +4,7 @@ var compare = require("ver-compare").compareVersions;
 
 module.exports = function(callback) {
   exec("psc", true, ["--version"], process.env, function(err, ver) {
+    if (err) return callback(err)
     ver = ver.trim();
     if (compare(ver, "0.7.0.0") < 0) {
       log.error("This version of Pulp requires PureScript version 0.7.0.0 or higher.");


### PR DESCRIPTION
PR to fix #53 ~~(incomplete)~~

Adds code which checks for a `.cmd` version of executables if they're not found.

Have manually tested all commands.
### ~~Problem 1~~

~~These commands don't work yet: `pulp docs`, `pulp psci`~~

~~This is because these commands use their own process-spawing code rather than using exec.js. I guess they can be rewritten to do so, but first wanted to check if there was any reason for this, and if I was on the right track with this PR anyway.~~
### ~~Problem 2~~

~~Using the `.cmd` files will trigger a "The command line is too long." error in projects that have lots of files/dependencies.~~

~~One resolution to this would be to have pulp pass the glob patterns straight to `psc` now that it supports them, instead of all the individual files. (Would also fix #51)~~

~~Another solution would be: instead of looking for a `.cmd` file on the path, look for the `.exe` file where npm puts it: `%AppData%/npm/node_modules/purescript/vendor`. It's more brittle that way, but maybe it's not a big deal.~~
