### PR TITLE
Refactor file globbing

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -9,23 +9,28 @@ var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
   log("Compiling...");
-  exec.psc([files.srcGlob, files.depsGlob], files.ffiGlobs, [
-    "--module=" + args.main, "--main=" + args.main
-  ].concat(args.remainder), null, function(err, src) {
-    if (err) return callback(err);
-    log("Compilation successful.");
-    log("Browserifying...");
-    var nodePath = process.env.NODE_PATH;
-    var buildPath = path.resolve(args.buildPath);
-    process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
-    var b = browserify({
-      basedir: buildPath,
-      entries: new stringStream(src)
-    });
-    if (args.transform) b.transform(args.transform);
-    b.bundle().pipe(args.to ? fs.createWriteStream(args.to) : process.stdout)
-      .on("close", callback);
-  });
+  var globSet = files.defaultGlobs;
+
+  exec.psc(
+    globSet.sources(),
+    globSet.ffis(),
+    ["--module=" + args.main, "--main=" + args.main].concat(args.remainder),
+    null, function(err, src) {
+      if (err) return callback(err);
+      log("Compilation successful.");
+      log("Browserifying...");
+      var nodePath = process.env.NODE_PATH;
+      var buildPath = path.resolve(args.buildPath);
+      process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
+      var b = browserify({
+        basedir: buildPath,
+        entries: new stringStream(src)
+      });
+      if (args.transform) b.transform(args.transform);
+      b.bundle().pipe(args.to ? fs.createWriteStream(args.to) : process.stdout)
+        .on("close", callback);
+    }
+  );
 }
 
 function incremental(pro, args, callback) {

--- a/build.js
+++ b/build.js
@@ -5,10 +5,11 @@ var fs = require("fs");
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  
+  var globSet = files.defaultGlobs;
+
   exec.psc(
-    [files.srcGlob, files.depsGlob],
-    files.ffiGlobs,
+    globSet.sources(),
+    globSet.ffis(),
     ["-o", args.buildPath].concat(args.remainder),
     null, function(err, rv) {
       if (err) return callback(err);
@@ -16,7 +17,7 @@ module.exports = function(pro, args, callback) {
       if (args.optimise) {
         log("Bundling Javascript...");
         exec.pscBundle(
-          [files.outputModules(args.buildPath)], 
+          [files.outputModules(args.buildPath)],
           [
             "--module=" + args.main, "--main=" + args.main
           ].concat(args.remainder), null, function(err, src) {

--- a/files.js
+++ b/files.js
@@ -11,7 +11,7 @@ function readJson(fn) {
   }
 }
 
-var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*/");
+var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*", "src");
 
 function SourceFileGlobSet(dirs) {
   if (!(this instanceof SourceFileGlobSet)) {

--- a/files.js
+++ b/files.js
@@ -1,5 +1,5 @@
-var glob = require("glob");
 var fs = require("fs");
+var glob = require("glob");
 var path = require("path");
 
 
@@ -13,50 +13,42 @@ function readJson(fn) {
 
 var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*/");
 
-exports.srcGlob = "src/**/*.purs";
-exports.depsGlob = bowerDirs + exports.srcGlob;
-exports.testGlob = "test/**/*.purs";
-exports.ffiGlobs = ["src/**/*.js", bowerDirs + "src/**/*.js", "test/**/*.js"];
-
-function deps(callback) {
-  var bowerrc = readJson(".bowerrc");
-  if (bowerrc.directory) {
-    glob(bowerrc.directory + "/purescript-*/src/**/*.purs", {}, callback);
-  } else {
-    glob("bower_components/purescript-*/src/**/*.purs", {}, callback);
+function SourceFileGlobSet(dirs) {
+  if (!(this instanceof SourceFileGlobSet)) {
+    return new this(dirs);
   }
-}
-module.exports.deps = deps;
 
-function depsForeign(callback) {
-  var bowerrc = readJson(".bowerrc");
-  if (bowerrc.directory) {
-    glob(bowerrc.directory + "/purescript-*/src/**/*.js", {}, callback);
-  } else {
-    glob("bower_components/purescript-*/src/**/*.js", {}, callback);
-  }
+  this._dirs = dirs;
 }
-module.exports.depsForeign = depsForeign;
 
-function src(callback) {
-  glob("src/**/*.purs", {}, callback);
-}
-module.exports.src = src;
+SourceFileGlobSet.prototype.union = function union(other) {
+  var removeDuplicates = function(arr) {
+    return arr.filter(function(elem, pos) {
+      return arr.indexOf(elem) == pos;
+    });
+  };
+  var dirsUnion = removeDuplicates(this._dirs.concat(other._dirs));
+  return new SourceFileGlobSet(dirsUnion);
+};
 
-function srcForeign(callback) {
-  glob("src/**/*.js", {}, callback);
-}
-module.exports.srcForeign = srcForeign;
+SourceFileGlobSet.prototype.sources = function sources() {
+  return this._dirs.map(function(d) {
+    return d + "/**/*.purs";
+  });
+};
 
-function test(callback) {
-  glob("test/**/*.purs", {}, callback);
-}
-module.exports.test = test;
+SourceFileGlobSet.prototype.ffis = function ffis() {
+  return this._dirs.map(function(d) {
+    return d + "/**/*.js";
+  });
+};
 
-function testForeign(callback) {
-  glob("test/**/*.js", {}, callback);
-}
-module.exports.testForeign = testForeign;
+exports.emptyGlobs      = new SourceFileGlobSet([]);
+exports.localGlobs      = new SourceFileGlobSet(["src"]);
+exports.dependencyGlobs = new SourceFileGlobSet([bowerDirs]);
+exports.testGlobs       = new SourceFileGlobSet(["test"]);
+
+exports.defaultGlobs = exports.localGlobs.union(exports.dependencyGlobs);
 
 function outputModules(buildPath) {
   return function(callback) {
@@ -64,6 +56,17 @@ function outputModules(buildPath) {
   };
 }
 module.exports.outputModules = outputModules;
+
+function resolveGlobs(patterns, callback) {
+  var fns = patterns.map(function(pattern) {
+    return function(cb) {
+      glob(pattern, {}, cb);
+    }
+  });
+
+  resolve(fns, callback);
+}
+module.exports.resolveGlobs = resolveGlobs;
 
 function resolve(fns, callback) {
   function it(acc, fns, callback) {

--- a/psci.js
+++ b/psci.js
@@ -13,8 +13,9 @@ function updateConfig(callback) {
              e.indexOf(":foreign ") !== 0 &&
              e.trim().length; 
     });
-    files.resolve([files.src, files.test, files.deps], function(err, deps) {
-      files.resolve([files.srcForeign, files.testForeign, files.depsForeign], function(err, ffi) {
+    var globSet = files.defaultGlobs.union(files.testGlobs);
+    files.resolveGlobs(globSet.sources(), function(err, deps) {
+      files.resolveGlobs(globSet.ffis(), function(err, ffi) {
         var psci = entries.concat(deps.map(function(path) { 
           return ":load " + path; 
         })).concat(ffi.map(function(path) {

--- a/test.js
+++ b/test.js
@@ -10,13 +10,15 @@ module.exports = function(pro, args, callback) {
     log("Tests OK.");
     callback();
   };
-  
+  var globSet = files.defaultGlobs.union(files.testGlobs);
+
   exec.psc(
-    [files.srcGlob, files.testGlob, files.depsGlob],
-    files.ffiGlobs,
-    ["-o", args.buildPath], null, function(err, rv) {
+    globSet.sources(),
+    globSet.ffis(),
+    ["-o", args.buildPath],
+    null, function(err, rv) {
       if (err) return callback(err);
-      
+
       if (args.testRuntime) {
         if (!args.to) args.to = "./output/test.js";
         log("Build successful. Bundling Javascript...");


### PR DESCRIPTION
Adds a new 'class' SourceFileGlobSet, which just keeps track of an array
of directories, as well as providing functions to turn this into an
array of globs (by appending either `**/*.purs` or `**/*.js` to each).

This simplifies code which uses globs, and ensures that the source
directories and foreign directories don't get out of sync.
