### PR TITLE
Add --include option.

### DIFF
--- a/args.js
+++ b/args.js
@@ -1,4 +1,5 @@
 var merge = require("merge");
+var fs = require("fs");
 
 function wrap(s, indent) {
   var w = require("wordwrap").hard;
@@ -60,6 +61,20 @@ function file(arg, stream) {
   }
 };
 module.exports.file = file;
+
+function directories(arg, stream) {
+  if (!stream[0]) return argErr(arg, "Needs a directory argument.");
+  var dirnames = stream[0].split(/\s+/).filter(function(s) { return s !== '' });
+  var notExists = dirnames.filter(function(d) { return !fs.existsSync(d) });
+  if (notExists.length === 0) {
+    return [dirnames, stream.slice(1)];
+  } else {
+    var quoted = notExists.map(function(f) { return "'" + f + "'" })
+    var directories = notExists.length === 1 ? "Directory" : "Directories"
+    return argErr(arg, directories + ": " + quoted.join(' ') + " not found.");
+  }
+}
+module.exports.directories = directories;
 
 function helpOpt(context, stream) {
   return ["--help", "-h"].indexOf(stream[0]) >= 0 ?
@@ -209,6 +224,7 @@ function printOpts(options, stream) {
     var key = next.match.join(" ");
     if (next.type === file) key += " <file>";
     else if (next.type === string) key += " <string>";
+    else if (next.type === directories) key += " <dirs>";
     var desc = next.desc;
     if (next.defaultValue) desc += " [Default: \"" + next.defaultValue + "\"]";
     acc[key] = desc;

--- a/browserify.js
+++ b/browserify.js
@@ -9,23 +9,28 @@ var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
   log("Compiling...");
-  exec.psc([files.srcGlob, files.depsGlob], files.ffiGlobs, [
-    "--module=" + args.main, "--main=" + args.main
-  ].concat(args.remainder), null, function(err, src) {
-    if (err) return callback(err);
-    log("Compilation successful.");
-    log("Browserifying...");
-    var nodePath = process.env.NODE_PATH;
-    var buildPath = path.resolve(args.buildPath);
-    process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
-    var b = browserify({
-      basedir: buildPath,
-      entries: new stringStream(src)
-    });
-    if (args.transform) b.transform(args.transform);
-    b.bundle().pipe(args.to ? fs.createWriteStream(args.to) : process.stdout)
-      .on("close", callback);
-  });
+  var globSet = files.defaultGlobs;
+
+  exec.psc(
+    globSet.sources(),
+    globSet.ffis(),
+    ["--module=" + args.main, "--main=" + args.main].concat(args.remainder),
+    null, function(err, src) {
+      if (err) return callback(err);
+      log("Compilation successful.");
+      log("Browserifying...");
+      var nodePath = process.env.NODE_PATH;
+      var buildPath = path.resolve(args.buildPath);
+      process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
+      var b = browserify({
+        basedir: buildPath,
+        entries: new stringStream(src)
+      });
+      if (args.transform) b.transform(args.transform);
+      b.bundle().pipe(args.to ? fs.createWriteStream(args.to) : process.stdout)
+        .on("close", callback);
+    }
+  );
 }
 
 function incremental(pro, args, callback) {

--- a/browserify.js
+++ b/browserify.js
@@ -9,7 +9,7 @@ var stringStream = require("string-stream");
 
 function optimising(pro, args, callback) {
   log("Compiling...");
-  var globSet = files.defaultGlobs;
+  var globSet = files.defaultGlobs.union(files.SourceFileGlobSet(args.includePaths));
 
   exec.psc(
     globSet.sources(),

--- a/build.js
+++ b/build.js
@@ -5,7 +5,7 @@ var fs = require("fs");
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  var globSet = files.defaultGlobs;
+  var globSet = files.defaultGlobs.union(files.SourceFileGlobSet(args.includePaths));
 
   exec.psc(
     globSet.sources(),

--- a/build.js
+++ b/build.js
@@ -5,10 +5,11 @@ var fs = require("fs");
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  
+  var globSet = files.defaultGlobs;
+
   exec.psc(
-    [files.srcGlob, files.depsGlob],
-    files.ffiGlobs,
+    globSet.sources(),
+    globSet.ffis(),
     ["-o", args.buildPath].concat(args.remainder),
     null, function(err, rv) {
       if (err) return callback(err);
@@ -16,7 +17,7 @@ module.exports = function(pro, args, callback) {
       if (args.optimise) {
         log("Bundling Javascript...");
         exec.pscBundle(
-          [files.outputModules(args.buildPath)], 
+          [files.outputModules(args.buildPath)],
           [
             "--module=" + args.main, "--main=" + args.main
           ].concat(args.remainder), null, function(err, src) {

--- a/files.js
+++ b/files.js
@@ -15,11 +15,12 @@ var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", 
 
 function SourceFileGlobSet(dirs) {
   if (!(this instanceof SourceFileGlobSet)) {
-    return new this(dirs);
+    return new SourceFileGlobSet(dirs);
   }
 
-  this._dirs = dirs;
+  this._dirs = dirs || [];
 }
+module.exports.SourceFileGlobSet = SourceFileGlobSet;
 
 SourceFileGlobSet.prototype.union = function union(other) {
   var removeDuplicates = function(arr) {
@@ -43,12 +44,12 @@ SourceFileGlobSet.prototype.ffis = function ffis() {
   });
 };
 
-exports.emptyGlobs      = new SourceFileGlobSet([]);
-exports.localGlobs      = new SourceFileGlobSet(["src"]);
-exports.dependencyGlobs = new SourceFileGlobSet([bowerDirs]);
-exports.testGlobs       = new SourceFileGlobSet(["test"]);
+module.exports.emptyGlobs      = new SourceFileGlobSet([]);
+module.exports.localGlobs      = new SourceFileGlobSet(["src"]);
+module.exports.dependencyGlobs = new SourceFileGlobSet([bowerDirs]);
+module.exports.testGlobs       = new SourceFileGlobSet(["test"]);
 
-exports.defaultGlobs = exports.localGlobs.union(exports.dependencyGlobs);
+module.exports.defaultGlobs = exports.localGlobs.union(exports.dependencyGlobs);
 
 function outputModules(buildPath) {
   return function(callback) {

--- a/files.js
+++ b/files.js
@@ -11,7 +11,7 @@ function readJson(fn) {
   }
 }
 
-var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*/");
+var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*", "src");
 
 function SourceFileGlobSet(dirs) {
   if (!(this instanceof SourceFileGlobSet)) {

--- a/files.js
+++ b/files.js
@@ -1,5 +1,5 @@
-var glob = require("glob");
 var fs = require("fs");
+var glob = require("glob");
 var path = require("path");
 
 
@@ -13,50 +13,42 @@ function readJson(fn) {
 
 var bowerDirs = path.join(readJson(".bowerrc").directory || "bower_components", "purescript-*/");
 
-exports.srcGlob = "src/**/*.purs";
-exports.depsGlob = bowerDirs + exports.srcGlob;
-exports.testGlob = "test/**/*.purs";
-exports.ffiGlobs = ["src/**/*.js", bowerDirs + "src/**/*.js", "test/**/*.js"];
-
-function deps(callback) {
-  var bowerrc = readJson(".bowerrc");
-  if (bowerrc.directory) {
-    glob(bowerrc.directory + "/purescript-*/src/**/*.purs", {}, callback);
-  } else {
-    glob("bower_components/purescript-*/src/**/*.purs", {}, callback);
+function SourceFileGlobSet(dirs) {
+  if (!(this instanceof SourceFileGlobSet)) {
+    return new this(dirs);
   }
-}
-module.exports.deps = deps;
 
-function depsForeign(callback) {
-  var bowerrc = readJson(".bowerrc");
-  if (bowerrc.directory) {
-    glob(bowerrc.directory + "/purescript-*/src/**/*.js", {}, callback);
-  } else {
-    glob("bower_components/purescript-*/src/**/*.js", {}, callback);
-  }
+  this._dirs = dirs;
 }
-module.exports.depsForeign = depsForeign;
 
-function src(callback) {
-  glob("src/**/*.purs", {}, callback);
-}
-module.exports.src = src;
+SourceFileGlobSet.prototype.union = function union(other) {
+  var removeDuplicates = function(arr) {
+    return arr.filter(function(elem, pos) {
+      return arr.indexOf(elem) == pos;
+    });
+  };
+  var dirsUnion = removeDuplicates(this._dirs.concat(other._dirs));
+  return new SourceFileGlobSet(dirsUnion);
+};
 
-function srcForeign(callback) {
-  glob("src/**/*.js", {}, callback);
-}
-module.exports.srcForeign = srcForeign;
+SourceFileGlobSet.prototype.sources = function sources() {
+  return this._dirs.map(function(d) {
+    return d + "/**/*.purs";
+  });
+};
 
-function test(callback) {
-  glob("test/**/*.purs", {}, callback);
-}
-module.exports.test = test;
+SourceFileGlobSet.prototype.ffis = function ffis() {
+  return this._dirs.map(function(d) {
+    return d + "/**/*.js";
+  });
+};
 
-function testForeign(callback) {
-  glob("test/**/*.js", {}, callback);
-}
-module.exports.testForeign = testForeign;
+exports.emptyGlobs      = new SourceFileGlobSet([]);
+exports.localGlobs      = new SourceFileGlobSet(["src"]);
+exports.dependencyGlobs = new SourceFileGlobSet([bowerDirs]);
+exports.testGlobs       = new SourceFileGlobSet(["test"]);
+
+exports.defaultGlobs = exports.localGlobs.union(exports.dependencyGlobs);
 
 function outputModules(buildPath) {
   return function(callback) {
@@ -64,6 +56,17 @@ function outputModules(buildPath) {
   };
 }
 module.exports.outputModules = outputModules;
+
+function resolveGlobs(patterns, callback) {
+  var fns = patterns.map(function(pattern) {
+    return function(cb) {
+      glob(pattern, {}, cb);
+    }
+  });
+
+  resolve(fns, callback);
+}
+module.exports.resolveGlobs = resolveGlobs;
 
 function resolve(fns, callback) {
   function it(acc, fns, callback) {

--- a/index.js
+++ b/index.js
@@ -24,11 +24,19 @@ var globals = [
   )
 ];
 
-var buildArgs = [
+/* Options common to both 'build' and 'test'. */
+var buildTestArgs = [
   args.option(
     "buildPath", ["--build-path", "-o"], args.string,
     "Path for compiler output.", "./output"
   ),
+  args.option(
+    "includePaths", ["--include", "-I"], args.directories,
+    "Additional directories for PureScript source files, separated by spaces."
+  )
+];
+
+var buildArgs = buildTestArgs.concat([
   args.option(
     "main", ["--main", "-m"], args.string,
     "Application's entry point.", "Main"
@@ -41,7 +49,7 @@ var buildArgs = [
     "to", ["--to", "-t"], args.string,
     "Output file name (stdout if not specified)."
   )
-];
+]);
 
 var commands = [
   args.command(
@@ -81,7 +89,7 @@ var commands = [
         "engine", ["--engine"], args.string,
         "Run the Application on a different JavaScript engine (node, iojs)", "node"
       )
-    ].concat([buildArgs[0]])
+    ].concat(buildTestArgs)
   ),
   args.command(
     "browserify", "Produce a deployable bundle using Browserify.",

--- a/psci.js
+++ b/psci.js
@@ -13,8 +13,9 @@ function updateConfig(callback) {
              e.indexOf(":foreign ") !== 0 &&
              e.trim().length; 
     });
-    files.resolve([files.src, files.test, files.deps], function(err, deps) {
-      files.resolve([files.srcForeign, files.testForeign, files.depsForeign], function(err, ffi) {
+    var globSet = files.defaultGlobs.union(files.testGlobs);
+    files.resolveGlobs(globSet.sources(), function(err, deps) {
+      files.resolveGlobs(globSet.ffis(), function(err, ffi) {
         var psci = entries.concat(deps.map(function(path) { 
           return ":load " + path; 
         })).concat(ffi.map(function(path) {

--- a/run.js
+++ b/run.js
@@ -8,7 +8,7 @@ var temp = require("temp").track();
 
 module.exports = function(pro, args, callback) {
   log("Building project in", process.cwd());
-  var globSet = files.defaultGlobs;
+  var globSet = files.defaultGlobs.union(files.SourceFileGlobSet(args.includePaths));
 
   exec.psc(
     globSet.sources(),

--- a/test.js
+++ b/test.js
@@ -10,13 +10,15 @@ module.exports = function(pro, args, callback) {
     log("Tests OK.");
     callback();
   };
-  
+  var globSet = files.defaultGlobs.union(files.testGlobs);
+
   exec.psc(
-    [files.srcGlob, files.testGlob, files.depsGlob],
-    files.ffiGlobs,
-    ["-o", args.buildPath], null, function(err, rv) {
+    globSet.sources(),
+    globSet.ffis(),
+    ["-o", args.buildPath],
+    null, function(err, rv) {
       if (err) return callback(err);
-      
+
       if (args.testRuntime) {
         if (!args.to) args.to = "./output/test.js";
         log("Build successful. Bundling Javascript...");

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ module.exports = function(pro, args, callback) {
     log("Tests OK.");
     callback();
   };
-  var globSet = files.defaultGlobs.union(files.testGlobs);
+  var globSet = files.defaultGlobs.union(files.SourceFileGlobSet(args.includePaths));
 
   exec.psc(
     globSet.sources(),


### PR DESCRIPTION
Depends on #60. 

Currently, if you want more than one directory, you have to specify it
once with quotes, eg:

$ pulp build -I "foo bar"

rather than:

$ pulp build -I foo -I bar

(which doesn't work, and gets interpreted the same way as if only "-I
bar" had been specified).
