### PR TITLE
Add more args to browserify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ it.
   output file using `--to`; the default is to output the bundle to
   stdout, which is convenient for doing things like `pulp browserify |
   uglifyjs -c`.
+
+  If you want to browserify your test suite, e.g. if you want to run
+  tests in the browser, you can run `pulp browserify -I test --main
+  Test.Main`.
 * `pulp docs` generates a project documentation file using
   PureScript's `psc-docs` command.
 * `pulp psci` launches a PureScript REPL using `psci` with the

--- a/index.js
+++ b/index.js
@@ -24,8 +24,12 @@ var globals = [
   )
 ];
 
-/* Options common to both 'build' and 'test'. */
-var buildTestArgs = [
+/* Options common to 'build', 'test' and 'browserify'. */
+var buildTestBrowserifyArgs = [
+  args.option(
+    "main", ["--main", "-m"], args.string,
+    "Application's entry point.", "Main"
+  ),
   args.option(
     "buildPath", ["--build-path", "-o"], args.string,
     "Path for compiler output.", "./output"
@@ -36,11 +40,7 @@ var buildTestArgs = [
   )
 ];
 
-var buildArgs = buildTestArgs.concat([
-  args.option(
-    "main", ["--main", "-m"], args.string,
-    "Application's entry point.", "Main"
-  ),
+var buildArgs = buildTestBrowserifyArgs.concat([
   args.option(
     "optimise", ["--optimise", "-O"], args.flag,
     "Perform dead code elimination."
@@ -89,13 +89,13 @@ var commands = [
         "engine", ["--engine"], args.string,
         "Run the Application on a different JavaScript engine (node, iojs)", "node"
       )
-    ].concat(buildTestArgs)
+    ].concat(buildTestBrowserifyArgs)
   ),
   args.command(
     "browserify", "Produce a deployable bundle using Browserify.",
     function() {
       return require("./browserify").apply(this, arguments);
-    }, buildArgs.concat([
+    }, buildTestBrowserifyArgs.concat([
       args.option(
         "transform", ["--transform"], args.string,
         "Apply a Browserify transform."


### PR DESCRIPTION
Fix for #58 

A new `--test` flag wasn't needed, I just reused the flags/args from the `build` command and documented how to use them for browserifying tests.

Let me know if something needs to be fixed! :)
