### PR TITLE
Fix pulp server on windows

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -20,7 +20,7 @@ function optimising(pro, args, callback) {
         log("Browserifying...");
         var nodePath = process.env.NODE_PATH;
         var buildPath = path.resolve(args.buildPath);
-        process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
+        process.env["NODE_PATH"] = nodePath ? (buildPath + path.delimiter + nodePath) : buildPath;
         var b = browserify({
           basedir: buildPath,
           entries: new stringStream(src)
@@ -47,7 +47,7 @@ function incremental(pro, args, callback) {
     var nodePath = process.env.NODE_PATH;
     var buildPath = path.resolve(args.buildPath);
     var cachePath = path.resolve(process.cwd(), ".browserify-cache.json");
-    process.env["NODE_PATH"] = nodePath ? (buildPath + ":" + nodePath) : buildPath;
+    process.env["NODE_PATH"] = nodePath ? (buildPath + path.delimiter + nodePath) : buildPath;
     if (args.force) {
       fs.unlinkSync(cachePath);
     }

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ module.exports = function(pro, args, callback) {
     if (err) return callback(err);
     var main = args.main.replace(".", path.sep) + ".purs";
     var entryPoint = main.replace("\\", "\\\\").replace("'", "\\'");
-    var src = "require('." + path.sep + entryPoint + "').main();\n";
+    var src = "require('." + path.sep.replace("\\", "\\\\") + entryPoint + "').main();\n";
     var entryPath = path.join("src", ".webpack.js");
     fs.writeFileSync(entryPath, src, "utf-8");
 


### PR DESCRIPTION
'\' is missing in path used by require in .webpack.js:
path.sep is '\' on Windows,
'.\Main' becomes '.Main'.
Adding .replace("\", "\\") solves the problem.
