### PR TITLE
Fix pulp server on windows (closes #74)

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ module.exports = function(pro, args, callback) {
     if (err) return callback(err);
     var main = args.main.replace(".", path.sep) + ".purs";
     var entryPoint = main.replace("\\", "\\\\").replace("'", "\\'");
-    var src = "require('." + path.sep + entryPoint + "').main();\n";
+    var src = "require('." + path.sep.replace("\\", "\\\\") + entryPoint + "').main();\n";
     var entryPath = path.join("src", ".webpack.js");
     fs.writeFileSync(entryPath, src, "utf-8");
 


### PR DESCRIPTION
'\' is missing in path used by require in .webpack.js:
path.sep is '\' on Windows,
'.\Main' becomes '.Main'.
Adding .replace("\", "\\") solves the problem.
.replace("\", "\\")
