### PR TITLE
Proposal to migrate to watchman

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ option, which will cause `pulp` to run indefinitely, watching your
 `src` and `test` folders for changes, and re-running the command
 whenever something changes.
 
+`pulp` requires [Watchman](https://facebook.github.io/watchman) to be
+installed. Please follow the
+[Watchman installation documentation](https://facebook.github.io/watchman/docs/install.html).
+
 ## License
 
 Copyright 2014 Bodil Stokke

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "browserify": "^11.0.0",
     "browserify-incremental": "^3.0.1",
     "concat-stream": "^1.4.6",
+    "fb-watchman": "^1.6.0",
     "glob": "^4.0.2",
     "merge": "^1.2.0",
     "minimatch": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "temp": "^0.8.1",
     "touch": "^1.0.0",
     "ver-compare": "^0.1.1",
-    "watch": "^0.11.0",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1",
     "wordwrap": "0.0.2"

--- a/watch.js
+++ b/watch.js
@@ -1,26 +1,94 @@
 var fs = require("fs");
+
 var path = require("path");
+
 var child = require("child_process");
+
+var watchman = require("fb-watchman");
+
 var log = require("./log");
-var Minimatch = require("minimatch").Minimatch;
+
+var client = new watchman.Client();
+
+var cwd = process.cwd();
+
+var watchDirectories =  [path.join(cwd, "src"), path.join(cwd, "bower_components"), path.join(cwd, "test")];
+
+var subscriptionPrefix = "pulp-";
+
+function subscribeToWatch(watchDirectory, watch, relativePath, callback) {
+  client.command(["clock", watch], function(error, res){
+    if (error) callback(error);
+    else {
+      var sub = {
+        expression: ["anyof", ["match", "*.purs"], ["match", "*.js"]],
+        fields: ["name", "size", "exists", "type"],
+        since: res.clock,
+        relative_root: relativePath
+      };
+
+      var subscriptionName = subscriptionPrefix + watchDirectory;
+
+      client.command(["subscribe", watch, subscriptionName, sub], function(error, res){
+        if (error) callback(error);
+        else {
+          client.on("subscription", function(res){
+            if (res.subscription === subscriptionName) {
+              callback(null);
+            }
+          });
+        }
+      });
+    }
+  });
+}
+
+function watchProject(watchDirectory, callback) {
+  client.command(["watch-project", watchDirectory], function (error, res){
+    if (error) callback(error);
+    else {
+      var watch = res.watch;
+
+      var relativePath = res.relative_path;
+
+      if (res.warning) {
+        log.error("Warning: " + res.warning);
+      }
+
+      log("Watch established on " + watch + " with relative path " + relativePath);
+
+      callback(null, {watch: watch, relativePath: relativePath});
+    }
+  });
+}
+
+function watch(callback) {
+  client.capabilityCheck({optional:[], required:["relative_root"]}, function (error, res){
+    if (error) {
+      log.error("Watchman capability check failed. Error" + error);
+
+      client.end();
+    }
+    else {
+      watchDirectories.forEach(function(watchDirectory){
+        watchProject(watchDirectory, function(error, res){
+          if (error) log.error("Failed to watch project " + watchDirectory + ". Error: " + error);
+          else {
+            subscribeToWatch(watchDirectory, res.watch, res.relativePath, function(error){
+              if (error) log.error("Failed to subscribe to watch. Error: " + error);
+              else {
+                callback();
+              }
+            });
+          }
+        });
+      });
+    }
+  });
+}
 
 function stripWatchArg(arg) {
   return arg !== "-w" && arg !== "--watch";
-}
-
-var match = new Minimatch("{src,test,bower_components}/**/*");
-
-function watch(match, act) {
-  require("watch").watchTree(".", {
-    interval: 1337,
-    ignoreDotFiles: true
-  }, function(f, curr, prev) {
-    if (!(typeof f === "object" && prev === null && curr === null)) {
-      if (match.match(f)) {
-        act(f);
-      }
-    }
-  });
 }
 
 module.exports = function() {
@@ -32,7 +100,7 @@ module.exports = function() {
     log("Source tree changed; restarting:");
     p = child.fork(mod, args);
   };
-  watch(match, change);
+  watch(change);
 };
 
 module.exports.watch = watch;

--- a/watch.js
+++ b/watch.js
@@ -65,17 +65,17 @@ function watchProject(watchDirectory, callback) {
 function watch(callback) {
   client.capabilityCheck({optional:[], required:["relative_root"]}, function (error, res){
     if (error) {
-      log.error("Watchman capability check failed. Error" + error);
+      log.error("Watchman capability check failed. " + error);
 
       client.end();
     }
     else {
       watchDirectories.forEach(function(watchDirectory){
         watchProject(watchDirectory, function(error, res){
-          if (error) log.error("Failed to watch project " + watchDirectory + ". Error: " + error);
+          if (error) log.error("Failed to watch project " + watchDirectory + ". " + error);
           else {
             subscribeToWatch(watchDirectory, res.watch, res.relativePath, function(error){
-              if (error) log.error("Failed to subscribe to watch. Error: " + error);
+              if (error) log.error("Failed to subscribe to watch. " + error);
               else {
                 callback();
               }


### PR DESCRIPTION
I've put together this PR to migrate the underlying watch mechanism to Facebook's [Watchman](https://facebook.github.io/watchman). The reason for the switch is because I experienced a CPU usage spike using [watch](https://www.npmjs.com/package/watch) on a project with a large number of files outside of the `src` directory.

My guess was that this high CPU usage was caused by [watchTree](https://github.com/bodil/pulp/blob/6e889036290b2e54b636a17e1fa7b41a41d798b7/watch.js#L14) being passed `.` for the root because manually changing `.` to `src` brought the CPU usage back down to normal.

While this PR is one possible solution to the issue described above, the main goal is to spark a discussion. I was thinking of three possibilities for resolving the CPU issue:
1. Keep using `watch` and invoke `watchTree` on three roots: `src`, `bower_components`, and `test`.
2. Migrate to Watchman because it has baked-in support for multiple watch roots.
3. Migrate to Webpack's [Watchpack](https://www.npmjs.com/package/watchpack) because it also has baked-in support for multiple directories.

After my (admittedly informal/ad-hoc) evaluation of the options, I thought that Watchman offered a more robust feature set and seemed to be quite performant and light on the CPU. The one drawback is that it requires the Watchman service to be installed separately. However, at least with `brew`, it is a snap to install.

What is your take on this? I am open to discussing the Watchman choice further. I am also definitely open to shifting this PR to one of the other possibilities listed above, or discussing any other ideas on this matter.
