### PR TITLE
Find Bower with require.resolve

### DIFF
--- a/bower.js
+++ b/bower.js
@@ -8,8 +8,8 @@ module.exports = (function() {
   };
 
   exp.launchBower = function(bowerArgs, callback) {
-    var executable = "bower";
-    exec(path.join(__dirname, "node_modules", ".bin", executable), false,
+    var executable = path.join(require.resolve("bower"), "..", "..", "bin", "bower");
+    exec(executable, false,
       bowerArgs, process.env, callback);
   };
 


### PR DESCRIPTION
This pull request fixes #68. It uses [`require.resolve`](https://nodejs.org/api/globals.html#globals_require_resolve) to find Bower's `index.js`, then uses that to find the `bower` executable. 

I think there's probably a better way to do this. 
