### PR TITLE
Allow passing additional modules to psc-bundle

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,11 +16,17 @@ module.exports = function(pro, args, callback) {
       log("Build successful.");
       if (args.optimise || args.to) {
         log("Bundling Javascript...");
+
+        var bundleArgs = [
+          "--module=" + args.main, "--main=" + args.main
+        ].concat(
+          (args.modules || "").split(",").map(function(m) { return "--module=" + m; }),
+          args.remainder
+        );
+
         exec.pscBundle(
           [files.outputModules(args.buildPath)],
-          [
-            "--module=" + args.main, "--main=" + args.main
-          ].concat(args.remainder), null, function(err, src) {
+          bundleArgs, null, function(err, src) {
             if (err) return callback(err);
             var out = args.to ? fs.createWriteStream(args.to) : process.stdout;
             out.write(src, "utf-8", function(err) {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ var buildArgs = buildishArgs.concat([
   args.option(
     "to", ["--to", "-t"], args.string,
     "Output file name (stdout if not specified)."
+  ),
+  args.option(
+    "modules", ["--modules"], args.string,
+    "Additional modules to be included in the output bundle (comma-separated list)."
   )
 ]);
 


### PR DESCRIPTION
I need to make sure that these additional modules are included in the bundle, otherwise psc-bundle will strip them out because they appear unused.
