### PR TITLE
Make browserify fail if psc returned an error

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -11,6 +11,7 @@ var merge = require("merge");
 
 function optimising(pro, args, callback) {
   var fn = function(err) {
+    if (err) return callback(err);
     var globSet = files.defaultGlobs.union(files.SourceFileGlobSet(args.includePaths));
     exec.pscBundle(
       [files.outputModules(args.buildPath)],


### PR DESCRIPTION
Currently, `pulp browserify -O` just ignores compiler errors and continues, eventually returning `0` as an exit code. This should make pulp fail on compiler errors.
