### PR TITLE
Restrict bower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "ansi": "^0.3.0",
-    "bower": "*",
+    "bower": "^1.6.5",
     "browserify": "^11.0.0",
     "browserify-incremental": "^3.0.1",
     "concat-stream": "^1.4.6",


### PR DESCRIPTION
I've just put the latest one there, but probably we should allow some older versions.

This might prevent some problems when people are having a very old bower installed globally.
