### PR TITLE
Implement Pulp.Validate and Pulp.Data.Version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,8 @@
     "purescript-console": "~0.1.1",
     "purescript-unsafe-coerce": "~0.1.0",
     "purescript-profunctor": "~0.3.1",
-    "purescript-nullable": "~0.2.1"
+    "purescript-nullable": "~0.2.1",
+    "purescript-globals": "~0.2.1",
+    "purescript-integers": "~0.2.1"
   }
 }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -18,6 +18,7 @@ import Pulp.Args.Parser (parse)
 import Pulp.System.FFI
 import qualified Pulp.System.Log as Log
 import Pulp.System.Process (argv, exit)
+import Pulp.Validate (validate)
 
 globals :: Array Args.Option
 globals = [
@@ -102,6 +103,7 @@ main = runAff failed succeeded do
       Log.err $ "Error: " ++ err
       printHelp Log.out globals commands
     Right opts -> do
+      validate
       Log.log $ "Globals: " ++ show opts.globalOpts
       Log.log $ "Command: " ++ opts.command.name
       Log.log $ "Locals: " ++ show opts.commandOpts

--- a/src/Pulp/Data/Version.purs
+++ b/src/Pulp/Data/Version.purs
@@ -1,0 +1,70 @@
+module Pulp.Data.Version
+  ( Version(..)
+  , runVersion
+  , showVersion
+  , parseVersion
+  ) where
+
+import Prelude
+import Data.Either
+import Data.Maybe
+import Data.Int (fromNumber)
+import Data.String (fromCharArray, toCharArray, joinWith)
+import Data.List (List(), toList, fromList, some, null)
+import Data.Function (on)
+import Data.Foldable
+import Data.Maybe.Unsafe (fromJust)
+import Control.Apply ((<*))
+import Control.Monad (unless)
+import Control.Monad.State.Class (get)
+import Global (readInt)
+import Text.Parsing.Parser (Parser(), PState(..), ParseError(..), runParser, fail)
+import Text.Parsing.Parser.Token (when)
+import Text.Parsing.Parser.String (string)
+import Text.Parsing.Parser.Combinators (sepBy)
+import Text.Parsing.Parser.Pos (Position(), initialPos)
+
+import Pulp.System.FFI
+
+newtype Version = Version (List Int)
+
+runVersion :: Version -> List Int
+runVersion (Version xs) = xs
+
+showVersion :: Version -> String
+showVersion = joinWith "." <<< fromList <<< map show <<< runVersion
+
+isDigit :: Char -> Boolean
+isDigit c = '0' <= c && c <= '9'
+
+int :: Parser (List Char) Int
+int = (fromJust <<< parseInt <<< fromCharArray <<< fromList) <$> some (when lieAboutPos isDigit)
+
+lieAboutPos :: forall a. a -> Position
+lieAboutPos = const initialPos
+
+dot :: Parser (List Char) Unit
+dot = void $ when lieAboutPos (== '.')
+
+parseInt :: String -> Maybe Int
+parseInt = fromNumber <<< readInt 10
+
+version :: Parser (List Char) Version
+version = Version <$> (int `sepBy` dot) <* eof
+
+parseVersion :: String -> Either ParseError Version
+parseVersion = flip runParser version <<< toList <<< toCharArray
+
+eof :: forall a. Parser (List a) Unit
+eof =
+  get >>= \(input :: List a) ->
+    unless (null input) (fail "expected eof")
+
+instance eqVersion :: Eq Version where
+  eq = eq `on` runVersion
+
+instance ordVersion :: Ord Version where
+  compare = compare `on` runVersion
+
+instance _showVersion :: Show Version where
+  show (Version xs) = "(Version " <> show xs <> ")"

--- a/src/Pulp/Exec.js
+++ b/src/Pulp/Exec.js
@@ -7,6 +7,17 @@ exports.isENOENT = function isENOENT(error) {
   return error.code === "ENOENT";
 };
 
-exports["concatStream'"] = function exec$prime(stream, callback) {
-  stream.pipe(require("concat-stream")(callback));
+exports["concatStream'"] = function concatStream$prime(stream, callback) {
+  var concat = require("concat-stream");
+
+  var onSuccess = function(buf) {
+    callback(null, buf.toString("utf-8"));
+  };
+
+  var onError = function(err) {
+    callback(err, null);
+  }
+
+  stream.on('error', onError);
+  stream.pipe(concat(onSuccess));
 }

--- a/src/Pulp/Exec.purs
+++ b/src/Pulp/Exec.purs
@@ -59,7 +59,7 @@ shareAllButStdout = shareAll { stdout = Pipe }
 -- | pulp, which usually means they will immediately appear in the terminal).
 exec :: forall e. String -> Array String -> Maybe (StrMap String) -> AffN e Unit
 exec cmd args env = do
-  child <- spawn cmd args (toNullable env) shareAll
+  child <- liftEff $ spawn cmd args (toNullable env) shareAll
   attempt (wait child) >>= either (handleErrors cmd retry) onExit
 
   where
@@ -73,7 +73,7 @@ exec cmd args env = do
 -- | captured and returned as a String.
 execQuiet :: forall e. String -> Array String -> Maybe (StrMap String) -> AffN e String
 execQuiet cmd args env = do
-  child <- spawn cmd args (toNullable env) shareAllButStdout
+  child <- liftEff $ spawn cmd args (toNullable env) shareAllButStdout
   outVar <- makeVar
   forkAff (concatStream child.stdout >>= putVar outVar)
   attempt (wait child) >>= either (handleErrors cmd retry) (onExit outVar)

--- a/src/Pulp/System/ChildProcess.js
+++ b/src/Pulp/System/ChildProcess.js
@@ -1,11 +1,15 @@
 
 // module Pulp.System.ChildProcess
 
-exports["spawn'"] = function spawn$prime(cmd, args, env, stdio, callback) {
-  var opts = { env: env, stdio: stdio };
-  require("child_process").spawn(cmd, args, opts, callback);
+exports["spawn'"] = function spawn$prime(cmd, args, env, stdio) {
+  return function() {
+    var opts = { env: env, stdio: stdio };
+    return require("child_process").spawn(cmd, args, opts);
+  }
 }
 
 exports["wait'"] = function wait$prime(child, callback) {
-  child.on("exit", callback);
+  child.on("exit", function(r) {
+    callback(null, r)
+  });
 }

--- a/src/Pulp/System/ChildProcess.purs
+++ b/src/Pulp/System/ChildProcess.purs
@@ -28,15 +28,15 @@ type ChildProcess =
   , stderr :: NodeStream String
   }
 
-spawn :: forall e. String -> Array String -> Nullable (StrMap String) -> StdIOOptions -> AffN e ChildProcess
-spawn cmd args env stdio = runNode $ runFn5 spawn' cmd args env (toActualStdIOOptions stdio)
+spawn :: forall e. String -> Array String -> Nullable (StrMap String) -> StdIOOptions -> EffN e ChildProcess
+spawn cmd args env stdio = runFn4 spawn' cmd args env (toActualStdIOOptions stdio)
 
-foreign import spawn' :: Fn5 String
-                             (Array String)
-                             (Nullable (StrMap String))
-                             ActualStdIOOptions
-                             (Callback ChildProcess)
-                             Unit
+foreign import spawn' :: forall e.
+  Fn4 String
+      (Array String)
+      (Nullable (StrMap String))
+      ActualStdIOOptions
+      (EffN e ChildProcess)
 
 wait :: forall e. ChildProcess -> AffN e Int
 wait child = runNode $ runFn2 wait' child

--- a/src/Pulp/Validate.purs
+++ b/src/Pulp/Validate.purs
@@ -1,0 +1,30 @@
+module Pulp.Validate (validate) where
+
+import Prelude
+import Data.String (trim)
+import Data.Maybe
+import Data.Either
+import Data.List (toList)
+import Control.Monad (when)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (error)
+
+import Pulp.Exec (execQuiet)
+import Pulp.Data.Version
+import Pulp.System.Process (exit)
+import Pulp.System.FFI
+import qualified Pulp.System.Log as Log
+
+validate :: forall e. AffN e Unit
+validate = do
+  verStr <- trim <$> execQuiet "psc" ["--version"] Nothing
+  ver <- either (throwError <<< error <<< show) pure $ parseVersion verStr
+  when (ver < minimumPscVersion) $ do
+    Log.err $ "This version of Pulp requires PureScript version 0.7.0.0 or higher."
+    Log.err $ "Your installed version is " <> verStr <> "."
+    Log.err $ "Please either upgrade PureScript or downgrade Pulp to version 3.x."
+    liftEff $ exit 1
+
+minimumPscVersion :: Version
+minimumPscVersion = Version (toList [0, 7, 0, 0])

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,60 @@
+module Test.Main where
+
+import Prelude
+import Data.Tuple
+import Data.List
+import Data.Either
+import Data.Foldable
+import Pulp.Data.Version
+import Control.Monad.Eff
+import Control.Monad.Eff.Exception
+import Control.Monad.Eff.Console hiding (error)
+import Text.Parsing.Parser (ParseError())
+
+type EffT a =
+  Eff (err :: EXCEPTION, console :: CONSOLE) a
+
+assertEqual :: forall a. (Show a, Eq a) => a -> a -> EffT Unit
+assertEqual x y =
+  if x == y
+    then return unit
+    else throwException $ error $ show x <> " did not equal " <> show y
+
+testVersions =
+  [ Tuple "0.0.0"     $ v [0,0,0]
+  , Tuple "0.0.1.1"   $ v [0,0,1,1]
+  , Tuple "6.3.4"     $ v [6,3,4]
+  , Tuple "13.26.346" $ v [13,26,346]
+  ]
+  where
+  v = Version <<< toList
+
+invalidVersions =
+  [ "lol"
+  , "0.1.2.lol"
+  , "🐱🐱🐱"
+  ]
+
+main = do
+  log "parseVersion, showVersion are inverses"
+  for_ testVersions \(Tuple str vers) -> do
+    log $ "  " <> str
+    parsed <- assertSuccess $ parseVersion str
+    assertEqual parsed vers
+    assertEqual str (showVersion vers)
+
+  log "invalid versions produce parse errors"
+  for_ invalidVersions $ \str -> do
+    log $ "  " <> str
+    case parseVersion str of
+      Right v -> err $ "expected parse error, got: " <> show v
+      Left _  -> return unit
+
+  where
+  err :: forall a. String -> EffT a
+  err = throwException <<< error
+
+  assertSuccess :: Either ParseError Version -> EffT Version
+  assertSuccess =
+    let onLeft = err <<< ("expected successful parse, got: " <>) <<< show
+    in either onLeft pure


### PR DESCRIPTION
- Fix some problems with FFI declarations:
  - spawn didn't need to be Aff, so is now just Eff
  - concatStream didn't turn the resulting Buffer into a String (despite
    the type signature claiming that this was the case)
- Add a basic test suite (only Pulp.Data.Version is tested at the
  moment)
- Implement `validate` to check the required minimum version of psc
  is installed.
- Added dependencies purescript-globals and purescript-integers, needed
  for the version parser.

I have tested `validate` by hand, it does fail if you're using a version of psc that's too old, but I haven't summoned the willpower to try writing a test for that yet.
