### PR TITLE
pulp init: Refuse to overwrite anything without --force.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.9",
+    "chai": "^3.4.1",
     "co": "^4.6.0",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -8,10 +8,13 @@ import Data.String (joinWith)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Eff.Class (liftEff)
+import Control.Monad (when)
 import Node.Path as Path
 import Node.FS.Aff (writeTextFile, exists)
 import Node.Encoding (Encoding(UTF8))
 import Node.Process as Process
+import Data.Traversable (for)
+import Data.Foldable (for_)
 
 import Pulp.Outputter
 import Pulp.System.FFI
@@ -61,37 +64,43 @@ testFile = unlines [
   "  log \"You should add some tests.\""
   ]
 
-init :: Outputter -> AffN Unit
-init out = do
+projectFiles :: String -> String -> Array { path :: String, content :: String }
+projectFiles pathRoot projectName =
+  [ { path: fullPath ["bower.json"],        content: bowerFile projectName }
+  , { path: fullPath [".gitignore"],        content: gitignore }
+  , { path: fullPath ["src", "Main.purs"],  content: mainFile }
+  , { path: fullPath ["test", "Main.purs"], content: testFile }
+  ]
+  where
+    fullPath pathParts = Path.concat ([pathRoot] ++ pathParts)
+
+
+init :: Boolean -> Outputter -> AffN Unit
+init force out = do
   cwd <- liftEff Process.cwd
-  let name = Path.basename cwd
+  let projectName = Path.basename cwd
   out.log $ "Generating project skeleton in " ++ cwd
 
-  writeFile (Path.concat [cwd, ".gitignore"]) gitignore
-  writeFile (Path.concat [cwd, "bower.json"]) (bowerFile name)
+  let files = projectFiles cwd projectName
 
-  mkdirIfNotExist "src"
-  writeFile (Path.concat [cwd, "src", "Main.purs"]) mainFile
+  when (not force) do
+    for_ files \f -> do
+      fileExists <- exists f.path
+      when fileExists do
+        throwError <<< error $ "Found " ++ f.path ++ ": "
+                               ++ "There's already a project here. Run `pulp init --force` "
+                               ++ "if you're sure you want to overwrite it."
 
-  mkdirIfNotExist "test"
-  writeFile (Path.concat [cwd, "test", "Main.purs"]) testFile
+  for files \f -> do
+    let dir = Path.dirname f.path
+    when (dir /= cwd) (mkdirIfNotExist dir)
+    writeTextFile UTF8 f.path f.content
 
   launchBower ["update"]
 
-  where
-  writeFile = writeTextFile UTF8
 
 action :: Action
 action = Action \args -> do
-  force     <- getFlag "force" args.commandOpts
-  cwd       <- liftEff Process.cwd
-  doesExist <- exists $ Path.concat [cwd, "bower.json"]
-
-  if (doesExist && not force)
-    then
-      throwError $ error $
-        "There's already a project here. Run `pulp init --force` if you're "
-        ++ "sure you want to overwrite it."
-    else do
-      out <- getOutputter args
-      init out
+  force <- getFlag "force" args.commandOpts
+  out   <- getOutputter args
+  init force out

--- a/test-js/sh.js
+++ b/test-js/sh.js
@@ -2,7 +2,7 @@ import co from "co";
 import { exec } from "child_process";
 import _temp from "temp";
 import { resolve } from "path";
-import assert from "assert";
+import { assert } from "chai";
 import fs from "fs";
 
 const temp = _temp.track();


### PR DESCRIPTION
Extends the existing `bower.json` check to cover the other files that get written out.

(Fixes #73.)
