### PR TITLE
init: add pulp cache folder to gitignore

### DIFF
--- a/init.js
+++ b/init.js
@@ -23,6 +23,7 @@ function bowerFile(name) {
 var gitignore = [
   "/bower_components/",
   "/node_modules/",
+  "/.pulp-cache/",
   "/output/",
   "/.psci*",
   "/src/.webpack.js"


### PR DESCRIPTION
It would be useful to gitignore this folder by default for `pulp init`-ed projects.
