### PR TITLE
Better bower.json defaults

### DIFF
--- a/init.js
+++ b/init.js
@@ -6,13 +6,14 @@ var bower = require("./bower");
 function bowerFile(name) {
   return JSON.stringify({
     name: name,
-    version: "1.0.0",
-    moduleType: ["node"],
     ignore: [
       "**/.*",
       "node_modules",
       "bower_components",
-      "output"
+      "output",
+      "test",
+      "bower.json",
+      "package.json",
     ],
     dependencies: {
       "purescript-console": "^0.1.0"


### PR DESCRIPTION
- The `version` field should not be used, as per https://github.com/bower/spec/blob/master/json.md#version
- Having "node" as the `moduleType` doesn't really seem right, since this won't contain CommonJS compatible files (no JS files at all, in fact)
- Added `test` to default ignored files - consumers of the package don't need the tests
- Added `bower.json` and `package.json` to default ignored files - neither are useful to consumers of the package, and bower makes its own `.bower.json` for packages it fetches, which inclues the details from `bower.json` along with details about how the fetched package was resolved.
