### PR TITLE
Update purescript-node-streams to ~0.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "purescript-node-fs-aff": "~0.2.1",
     "purescript-node-path": "~0.4.0",
     "purescript-sets": "~0.5.3",
-    "purescript-node-streams": "~0.2.0",
+    "purescript-node-streams": "~0.3.0",
     "purescript-ansi": "~0.1.2"
   }
 }

--- a/src/Pulp/Browserify.purs
+++ b/src/Pulp/Browserify.purs
@@ -128,7 +128,7 @@ type BrowserifyOptions =
   { basedir   :: String
   , src       :: String
   , transform :: Nullable String
-  , out       :: WritableStream String
+  , out       :: WritableStream
   }
 
 foreign import browserifyBundle' :: Fn2 BrowserifyOptions
@@ -143,7 +143,7 @@ type BrowserifyIncOptions =
   , cacheFile :: String
   , path      :: String
   , transform :: Nullable String
-  , out       :: WritableStream String
+  , out       :: WritableStream
   }
 
 foreign import browserifyIncBundle' :: Fn2 BrowserifyIncOptions

--- a/src/Pulp/Build.purs
+++ b/src/Pulp/Build.purs
@@ -103,7 +103,7 @@ bundle args = do
 
 -- | Get a writable stream which output should be written to, based on the
 -- | value of the 'to' option.
-getOutputStream :: Options -> AffN (WritableStream String)
+getOutputStream :: Options -> AffN WritableStream
 getOutputStream opts = do
   to <- getOption "to" opts
   case to of

--- a/src/Pulp/Exec.purs
+++ b/src/Pulp/Exec.purs
@@ -105,7 +105,7 @@ handleErrors cmd retry err
   | otherwise =
      throwError err
 
-concatStream :: ReadableStream String -> AffN String
+concatStream :: ReadableStream -> AffN String
 concatStream stream = runNode $ runFn2 concatStream' stream
 
-foreign import concatStream' :: Fn2 (ReadableStream String) (Callback String) Unit
+foreign import concatStream' :: Fn2 ReadableStream (Callback String) Unit

--- a/src/Pulp/Outputter.purs
+++ b/src/Pulp/Outputter.purs
@@ -60,7 +60,7 @@ ansiOutputter =
   , monochrome: false
   }
 
-bullet :: WritableStream String -> Color -> String -> AffN Unit
+bullet :: WritableStream -> Color -> String -> AffN Unit
 bullet stream color text = do
   withGraphics (write stream) (foreground color) "* "
   write stream (text <> "\n")

--- a/src/Pulp/System/ChildProcess.purs
+++ b/src/Pulp/System/ChildProcess.purs
@@ -18,9 +18,9 @@ import Pulp.System.FFI
 import Pulp.System.Stream
 
 type ChildProcess =
-  { stdin  :: WritableStream String
-  , stdout :: ReadableStream String
-  , stderr :: ReadableStream String
+  { stdin  :: WritableStream
+  , stdout :: ReadableStream
+  , stderr :: ReadableStream
   , pid    :: Int
   }
 
@@ -49,7 +49,7 @@ data StdIOBehaviour
   = Pipe
   | Ignore
   | FileDescriptor Int
-  | ShareStream (NodeStream String)
+  | ShareStream AnyStream
 
 foreign import data ActualStdIOBehaviour :: *
 

--- a/src/Pulp/System/Files.purs
+++ b/src/Pulp/System/Files.purs
@@ -35,7 +35,7 @@ foreign import openTemp' :: Fn2 TempOptions (Callback TempFileInfo) Unit
 openTemp :: TempOptions -> AffN TempFileInfo
 openTemp opts = runNode $ runFn2 openTemp' opts
 
-foreign import createWriteStream :: String -> EffN (WritableStream String)
+foreign import createWriteStream :: String -> EffN WritableStream
 
 foreign import isENOENT :: Error -> Boolean
 

--- a/src/Pulp/System/Process.purs
+++ b/src/Pulp/System/Process.purs
@@ -34,9 +34,9 @@ argv = drop 2 argv'
 
 foreign import exit :: forall a. Int -> EffN a
 
-foreign import stdin  :: ReadableStream String
-foreign import stdout :: WritableStream String
-foreign import stderr :: WritableStream String
+foreign import stdin  :: ReadableStream
+foreign import stdout :: WritableStream
+foreign import stderr :: WritableStream
 
 -- | Gets a copy of the current environment
 foreign import getEnvironment :: EffN (StrMap String)

--- a/src/Pulp/System/Stream.purs
+++ b/src/Pulp/System/Stream.purs
@@ -1,7 +1,7 @@
 module Pulp.System.Stream
   ( ReadableStream()
   , WritableStream()
-  , NodeStream()
+  , AnyStream()
   , forget
   , write
   ) where
@@ -9,23 +9,20 @@ module Pulp.System.Stream
 import Prelude
 import Control.Monad.Aff (makeAff)
 import Node.Stream as Node
+import Node.Encoding (Encoding(UTF8))
 import Unsafe.Coerce (unsafeCoerce)
 
 import Pulp.System.FFI
 
-type ReadableStream a = Node.Readable () PulpEffects a
-type WritableStream a = Node.Writable () PulpEffects a
+type ReadableStream = Node.Readable () PulpEffects
+type WritableStream = Node.Writable () PulpEffects
 
 -- | A stream which might or might not be readable or writable.
-foreign import data NodeStream :: * -> *
+foreign import data AnyStream :: *
 
 -- | Forget about whether a particular stream is readable or writable.
-forget :: forall eff r a. Node.Stream r eff a -> NodeStream a
+forget :: forall eff r. Node.Stream r eff -> AnyStream
 forget = unsafeCoerce
 
-write :: forall a. WritableStream a -> a -> AffN Unit
-write stream chunk = makeAff (\_ done -> void (Node.write (workaround stream) chunk (done unit)))
-  where
-  -- temporary workaround for https://github.com/purescript-node/purescript-node-streams/issues/3
-  workaround :: WritableStream a -> WritableStream String
-  workaround = unsafeCoerce
+write :: WritableStream -> String -> AffN Unit
+write stream str = makeAff (\_ done -> void (Node.writeString stream UTF8 str (done unit)))


### PR DESCRIPTION
The only real change here is that `Stream` now has one less type
argument. Updating will allow us to use other purescript-node bindings,
such as process and child-process.

I also renamed NodeStream to AnyStream, because it better describes what
it is.
