### PR TITLE
Adds a global --before option, in the style of --then

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ To continuously run your tests when you change the source code:
 $ pulp --watch test
 ```
 
+### Running Commands Before and After an Action
+
+It's sometimes useful to kick off a command before or after an action,
+particularly in combination with the `--watch` option above. To do
+this, you can use `--before` or `--then`:
+
+```sh
+$ pulp --watch --before clear build     # Clears the screen before builds.
+$ pulp --watch --then 'say Done' build  # On OS X, announces 'Done' after a build.
+```
+
+
 ### CommonJS Aware Builds
 
 Often, you'll want to go outside PureScript and leverage some of the

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -228,6 +228,21 @@ describe("integration tests", function() {
       "output did not contain \"" + hello + "\"");
   }));
 
+  it("pulp --before something build", run(function*(sh, pulp, assert, temp) {
+    yield pulp("init");
+
+    // In reality, this is likely to be a "--before clear" or something, but
+    // that's nightmarish to actually test.
+    touch.sync(path.join(temp, "before.txt"))
+    const mv = process.platform === "win32" ? "rename" : "mv"
+    yield pulp(`--before "${mv} before.txt after.txt" build --to out.js`);
+
+    const [out] = yield sh("node out.js");
+    assert.equal(out.trim(), hello);
+    assert.ok(fs.existsSync(path.join(temp, "after.txt")),
+      "test file before.txt was not found as after.txt");
+  }));
+
   it("pulp --then something build", run(function*(sh, pulp, assert) {
     yield pulp("init");
     const mv = process.platform === "win32" ? "rename" : "mv"


### PR DESCRIPTION
Like `--then`, `--before` runs a shell command before every action, including during `--watch` loops.

(Intended to address #116, but perhaps in a more general manner.)
