### PR TITLE
Specify files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
     "pulp": "index.js"
   },
   "main": "pulp.js",
+  "files": [
+    "index.js",
+    "pulp.js",
+    "src",
+    "bower.json",
+    "test-js",
+    ".jshintrc"
+  ],
   "scripts": {
     "lint": "jshint src",
     "compile": "psc -c -f \"src/**/*.js\" -f \"bower_components/purescript-*/src/**/*.js\" \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\"",


### PR DESCRIPTION
I recently noticed that the npm version of `pulp` has a bunch of stuff that shouldn't really be there. I don't think any of what's there now particularly matters, but I'd rather we were a bit more strict about what gets included, particularly because I think there's a nonzero risk that someday, something sensitive could be included.

This commit adds a whitelist of the bare minimum files required to not only run `pulp`, but also run all the scripts (build, lint, test...), too. I tested it locally and it seems to work.
