### PR TITLE
Warn on `pulp dep`

### DIFF
--- a/src/Pulp/Bower.purs
+++ b/src/Pulp/Bower.purs
@@ -18,7 +18,12 @@ import Pulp.System.Which (which)
 import Pulp.Outputter
 
 action :: Action
-action = Action \args -> launchBower args.remainder
+action = Action \args -> do
+  out <- getOutputter args
+  out.err "[warn] `pulp dep` is deprecated. Please use `bower` directly instead."
+  launchBower args.remainder
+  out.err "[warn] Just in case you missed the earlier warning:"
+  out.err "[warn] `pulp dep` is deprecated. Please use `bower` directly instead."
 
 launchBower :: Array String -> AffN Unit
 launchBower args = do


### PR DESCRIPTION
I made it warn at the beginning and the end, because bower often prints so much stuff so quickly that you don't have time to read the initial warning.
