### PR TITLE
Better UX on unsupported Node (<4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "test-js",
     ".jshintrc"
   ],
+  "engines": {
+    "node": ">= 4"
+  },
   "scripts": {
     "lint": "jshint src",
     "compile": "psc -c -f \"src/**/*.js\" -f \"bower_components/purescript-*/src/**/*.js\" \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\"",


### PR DESCRIPTION
- Add node >=4 to package.json `engines` field
- Add startup check that node >= 4.0.0 is being used.

I tested this on an Ubuntu VM with node 0.10.

Fixes #150 
