### PR TITLE
Adds missing "use strict" directive.

### DIFF
--- a/src/Pulp/System/Which.js
+++ b/src/Pulp/System/Which.js
@@ -1,3 +1,5 @@
 // module Pulp.System.Which
 
+"use strict";
+
 exports["which'"] = require("which");


### PR DESCRIPTION
jshint v2.9.1 is going to whinge at us when we upgrade to it: http://lpaste.net/4864373216627392512 (from IRC)

The real problem that paste's owner was having related to having an ancient version of npm (1.x), which installed a new -rc version of jshint, but it's still a real problem that'll hit us when we eventually upgrade.
