### PR TITLE
Add bower as a dev dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "stable"
-before_install:
-  - npm install -g bower
 script:
   - npm test
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ cache:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g bower
   - npm install
 
 # Post-install test scripts.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "babel": "^5.8.9",
+    "bower": "^1.7.7",
     "chai": "^3.4.1",
     "co": "^4.6.0",
     "fs-promise": "^0.3.1",


### PR DESCRIPTION
I did a fresh clone of the repo and ran into the following issue when running `npm install`:

```
> bower install && npm run build

sh: bower: command not found
```

I prefer not to have bower installed locally, and can only assume that this used to work because bower was previously bundled with pulp.
