### PR TITLE
Re-opens the `Prelude` import in the `init`'d project files.

### DIFF
--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -42,7 +42,7 @@ mainFile :: String
 mainFile = unlines [
   "module Main where",
   "",
-  "import Prelude (Unit)",
+  "import Prelude",
   "import Control.Monad.Eff (Eff)",
   "import Control.Monad.Eff.Console (CONSOLE, log)",
   "",
@@ -55,7 +55,7 @@ testFile :: String
 testFile = unlines [
   "module Test.Main where",
   "",
-  "import Prelude (Unit)",
+  "import Prelude",
   "import Control.Monad.Eff (Eff)",
   "import Control.Monad.Eff.Console (CONSOLE, log)",
   "",


### PR DESCRIPTION
I just ran into this myself today:

> Speaking of unfriendly: magic names for some implicit operations, eg. `not` for `!`, `bind` for `>>=` / `do …`. The Pulp hello world example breaks the minute you do something else with the "do" block, because it doesn't `import Prelude (Unit, bind)`.
> ...
> I think this particular example can be saved by having the Prelude be an open import and leaving the rest closed.

(Addresses #187.)
