### PR TITLE
Ignore .psa-stash et al.

### DIFF
--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -35,6 +35,7 @@ gitignore = unlines [
   "/.pulp-cache/",
   "/output/",
   "/.psc*",
+  "/.psa*",
   "/src/.webpack.js"
   ]
 


### PR DESCRIPTION
I can alphabetize them if you like? In personal projects I usually strip slashes as well to follow https://github.com/github/gitignore/blob/master/Node.gitignore. Both are purely aesthetic however.
