### PR TITLE
pulp-test: Allow passthrough flags to test program

### DIFF
--- a/src/Pulp/Test.purs
+++ b/src/Pulp/Test.purs
@@ -38,7 +38,7 @@ action = Action \args -> do
       buildPath <- getOption' "buildPath" opts
       env <- setupEnv buildPath
       exec runtime
-           (["-e", "require('" <> main <> "').main()"] <> args.remainder)
+           (["-e", "require('" <> main <> "').main()", "--"] <> args.remainder)
            (Just env)
     else do
       to <- getOption' "to" buildArgs.commandOpts

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -236,6 +236,12 @@ describe("integration tests", function() {
     assert.equal(out.trim(), test);
   }));
 
+  it("pulp test -- --something-node-wouldnt-like", run(function*(sh, pulp, assert, temp) {
+    yield pulp("init");
+    const [out] = yield pulp("test");
+    assert.equal(out.trim(), test);
+  }));
+
   it("pulp browserify", run(function*(sh, pulp, assert) {
     yield pulp("init");
     const [src] = yield pulp("browserify");


### PR DESCRIPTION
Fixes #239.

# Underlying problem

Node doesn't stop parsing arguments after reading an inline script.

**BAD**:
```
node -e "console.log(process.env)" --some-flag-node-wouldnt-like
```

**FINE**:
```
echo 'console.log(process.env);' > main.js
node main.js --some-flag-node-wouldnt-like
```