### PR TITLE
Initialize .purs-repl file.

### DIFF
--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -38,6 +38,11 @@ gitignore = unlines [
   "/.psa*"
   ]
 
+pursReplFile :: String
+pursReplFile = unlines [
+  "import Prelude"
+  ]
+
 mainFile :: String
 mainFile = unlines [
   "module Main where",
@@ -68,6 +73,7 @@ projectFiles :: String -> String -> Array { path :: String, content :: String }
 projectFiles pathRoot projectName =
   [ { path: fullPath ["bower.json"],        content: bowerFile projectName }
   , { path: fullPath [".gitignore"],        content: gitignore }
+  , { path: fullPath [".purs-repl"],        content: pursReplFile }
   , { path: fullPath ["src", "Main.purs"],  content: mainFile }
   , { path: fullPath ["test", "Main.purs"], content: testFile }
   ]


### PR DESCRIPTION
Would be nice to initialize a .purs-repl file having "import Prelude". This would allow newcomers to PS to do `pulp init` followed by `1+1` and not get a "Unknown operator (+)" error.

This file would only be read by psci/purs repl when https://github.com/purescript/purescript/pull/2735 is merged, and likely included in the PS v0.11 release.

I haven't build/tested this change, yet, as my `npm run build` is failing, and I can't find further instructions in this repo for building.