### PR TITLE
Remove psa dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.2",
     "psvm": "^0.1.3",
-    "purescript-psa": "^0.4.0",
+    "purescript-psa": "^0.5.0",
     "semver": "^5.1.0",
     "touch": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.2",
     "psvm": "^0.1.3",
-    "purescript-psa": "^0.5.0",
     "semver": "^5.1.0",
     "touch": "^1.0.0"
   }

--- a/scripts.js
+++ b/scripts.js
@@ -14,7 +14,7 @@ const path = require("path");
 
 const scripts = {
   "lint": "jshint src",
-  "compile": "psa -c \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\" --censor-lib --censor-codes=ImplicitImport,HidingImport",
+  "compile": "psc \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\"",
   "bundle": "psc-bundle \"output/*/*.js\" --output pulp.js --module Main --main Main",
   "test": "mocha test-js --require babel/register",
 };


### PR DESCRIPTION
I'm curious if this is the reason why the test suite is failing to find `psc`/`purs`. I need to open a PR to start an Appveyor job.

_Edit_: it seems that using psa-0.4.0 is necessary to build with 0.10.7, but then when running the tests, `psa` will try to call `psc` which doesn't exist.