### PR TITLE
Set 'no-cache' on static server

### DIFF
--- a/src/Pulp/System/StaticServer.js
+++ b/src/Pulp/System/StaticServer.js
@@ -3,7 +3,11 @@
 exports["new"] = function(path) {
   return function() {
     var s = require('node-static');
-    return new s.Server(path);
+    return new s.Server(path, {
+      headers: {
+        'cache-control': 'no-cache'
+      }
+    });
   };
 };
 


### PR DESCRIPTION
Before, `cache-control: max-age=3600` was used. This lead to browsers not re-fetching `app.js`.