### PR TITLE
Check entry points

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,9 +40,11 @@
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-versions": "^4.0.0",
     "purescript-now": "^3.0.0",
-    "purescript-foreign-generic": "^4.1.0"
+    "purescript-foreign-generic": "^4.1.0",
+    "purescript-externs-check": "^0.1.1"
   },
   "devDependencies": {
-    "purescript-debug": "^3.0.0"
+    "purescript-debug": "^3.0.0",
+    "purescript-psci-support": "^3.0.0"
   }
 }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -99,13 +99,15 @@ buildishArgs = [
   Args.optionDefault "buildPath" ["--build-path", "-o"] Type.string
     "Path for compiler output." "./output",
   Args.option "noPsa" ["--no-psa"] Type.flag
-    "Do not attempt to use the psa frontend instead of purs compile"
+    "Do not attempt to use the psa frontend instead of purs compile",
+  Args.option "noCheckMain" ["--no-check-main"] Type.flag
+    "Skip checking that the application has a suitable entry point."
   ] <> pathArgs
 
 runArgs :: Array Args.Option
 runArgs = [
   Args.optionDefault "main" ["--main", "-m"] Type.string
-    "Application's entry point." "Main",
+    "Module to be used as the application's entry point." "Main",
   Args.option "jobs" ["--jobs", "-j"] Type.int
     "Tell purs to use the specified number of cores."
   ] <> buildishArgs

--- a/src/Pulp/Browserify.purs
+++ b/src/Pulp/Browserify.purs
@@ -70,6 +70,10 @@ optimising = Action \args -> do
   skipEntryPoint' <- getFlag "skipEntryPoint" opts
   let skipEntryPoint = skipEntryPoint' || isJust standalone
 
+  skipMainCheck <- getFlag "noCheckMain" opts
+  when (not (skipEntryPoint || skipMainCheck))
+    (Build.checkEntryPoint out buildPath main)
+
   let bundleArgs = fold
         [ ["--module=" <> main]
         , if skipEntryPoint then [] else ["--main=" <> main]
@@ -113,6 +117,11 @@ incremental = Action \args -> do
   skipEntryPoint' <- getFlag "skipEntryPoint" opts
   let skipEntryPoint = skipEntryPoint' && isNothing standalone
   main <- getOption' "main" opts
+
+  noCheckMain <- getFlag "noCheckMain" opts
+  when (not (skipEntryPoint || noCheckMain))
+    (Build.checkEntryPoint out buildPath main)
+
   path <- if skipEntryPoint
             then
               pure $ Path.concat [buildPath, main]

--- a/src/Pulp/Run.purs
+++ b/src/Pulp/Run.purs
@@ -17,7 +17,6 @@ import Pulp.Args
 import Pulp.Args.Get
 import Pulp.Build as Build
 import Pulp.Exec
-import Pulp.Files
 import Pulp.Outputter
 import Pulp.System.Files (openTemp)
 import Pulp.System.FFI
@@ -31,6 +30,11 @@ action = Action \args -> do
 
   buildPath <- getOption' "buildPath" opts
   main <- getOption' "main" opts
+
+  noCheckMain <- getFlag "noCheckMain" opts
+  when (not (noCheckMain))
+    (Build.checkEntryPoint out buildPath main)
+
   src <- liftEff $ Buffer.fromString (makeEntry main) UTF8
 
   info <- openTemp { prefix: "pulp-run", suffix: ".js" }

--- a/src/Pulp/Test.purs
+++ b/src/Pulp/Test.purs
@@ -41,6 +41,11 @@ action = Action \args -> do
     then do
       main <- getOption' "main" opts
       buildPath <- getOption' "buildPath" opts
+
+      noCheckMain <- getFlag "noCheckMain" opts
+      when (not (noCheckMain))
+        (Build.checkEntryPoint out buildPath main)
+
       env <- setupEnv buildPath
       info <- openTemp { prefix: "pulp-test", suffix: ".js" }
       src <- liftEff $ Buffer.fromString (makeEntry main) UTF8


### PR DESCRIPTION
Adds a set of basic checks for the `build`, `browserify`, `run`, and
`test` commands that the entry point module is appropriate as an entry
point, and gives better errors if there's something wrong with it (e.g.
the entry point module does not exist, or does not export main, or
exports main but it has the wrong type).

refs purescript/purescript#2086