### PR TITLE
Always add project to args, resolves #300

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -264,11 +264,11 @@ runWithArgs args = do
   out <- getOutputter args
   _ <- validate out
   watch <- getFlag "watch" args.globalOpts
+  args' <- addProject args
   if watch && args.command.name /= "server"
     then
-      Args.runAction Watch.action args
+      Args.runAction Watch.action args'
     else do
-      args' <- addProject args
       runShellForOption "before" args'.globalOpts out
       result <- attempt $ Args.runAction args.command.action args'
       case result of


### PR DESCRIPTION
A quick fix for #300, but ideally this should be better typed as noted in the comment above `addProject`.