### PR TITLE
Relax main type check

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "purescript-versions": "^4.0.0",
     "purescript-now": "^3.0.0",
     "purescript-foreign-generic": "^4.1.0",
-    "purescript-externs-check": "^0.2.0"
+    "purescript-externs-check": "^1.0.0"
   },
   "devDependencies": {
     "purescript-debug": "^3.0.0",

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -105,8 +105,8 @@ buildishArgs = [
   Args.option "noCheckMain" ["--no-check-main"] Type.flag
     "Skip checking that the application has a suitable entry point.",
   Args.optionDefault "checkMainType" ["--check-main-type"] Type.string
-    "Override the type used for checking the application's entry point."
-    "Control.Monad.Eff.Eff"
+    "Specify an allowed list of types for the application's entry point (comma-separated list)."
+    "Effect.Effect,Control.Monad.Eff.Eff"
   ] <> pathArgs
 
 runArgs :: Array Args.Option

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -325,9 +325,10 @@ describe("integration tests", function() {
     );
 
     const [_, err] = yield pulp("build --to out.js", null, { expectedExitCode: 1 });
-    assert.match(err, /is not of type Control.Monad.Eff.Eff/);
+    assert.match(err, /is not in the allowed list of types/);
   }));
 
+  // Check with a single permissible `main` type
   it("pulp build --check-main-type Prim.Int", run(function*(sh, pulp, assert, temp) {
     yield pulp("init");
 
@@ -338,6 +339,34 @@ describe("integration tests", function() {
     );
 
     yield pulp("build --to out.js --check-main-type Prim.Int");
+    assert.exists("output/Main/index.js");
+  }));
+
+  // Check with a list of permissible `main` types
+  it("pulp build --check-main-type Prim.Boolean,Prim.Int", run(function*(sh, pulp, assert, temp) {
+    yield pulp("init");
+
+    const mainPath = path.join(temp, 'src', 'Main.purs');
+    yield fs.writeFile(
+      mainPath,
+      "module Main where\nmain = 0\n"
+    );
+
+    yield pulp("build --to out.js --check-main-type Prim.Boolean,Prim.Int");
+    assert.exists("output/Main/index.js");
+  }));
+
+  // Skip `main` type check
+  it("pulp build --no-check-main", run(function*(sh, pulp, assert, temp) {
+    yield pulp("init");
+
+    const mainPath = path.join(temp, 'src', 'Main.purs');
+    yield fs.writeFile(
+      mainPath,
+      "module Main where\nmain = 0\n"
+    );
+
+    yield pulp("build --to out.js --no-check-main");
     assert.exists("output/Main/index.js");
   }));
 


### PR DESCRIPTION
- Allow the user to supply a comma-separated list of types for `main`
- Default to allowing both Control.Monad.Eff.Eff and Effect.Effect

See also https://github.com/hdgarrood/purescript-externs-check/pull/1.

/cc @garyb 