### PR TITLE
Update generated project to use Effect

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1,55 +1,54 @@
 module Main where
 
-import Prelude
-
 import Control.Monad.Aff
 import Control.Monad.Eff.Class
+import Control.Monad.Eff.Exception
+import Prelude
+import Pulp.Args.Get
+import Pulp.Args.Help
+import Pulp.Outputter
+import Pulp.System.FFI
+
 import Control.Monad.Eff.Console as Console
 import Control.Monad.Eff.Unsafe (unsafePerformEff)
-import Control.Monad.Eff.Exception
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except (runExcept)
-import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Either (Either(..))
-import Data.Map (insert)
-import Data.Foreign (Foreign, toForeign, readString)
-import Data.Foreign.JSON (parseJSON)
-import Data.Foreign.Index (readProp)
 import Data.Array (head, drop)
+import Data.Either (Either(..))
 import Data.Foldable (elem)
-import Data.List (List(Nil))
-import Data.Version (Version(), version, showVersion, parseVersion)
+import Data.Foreign (Foreign, toForeign, readString)
+import Data.Foreign.Index (readProp)
+import Data.Foreign.JSON (parseJSON)
+import Data.List (List(Nil), fromFoldable)
+import Data.Map (insert)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (stripPrefix, Pattern(..))
-import Text.Parsing.Parser (parseErrorMessage)
+import Data.Version (Version, version, showVersion, parseVersion)
+import Data.Version.Haskell as HVer
 import Node.Encoding (Encoding(UTF8))
 import Node.FS.Sync (readTextFile)
 import Node.Path as Path
 import Node.Process as Process
-
 import Pulp.Args as Args
-import Pulp.Args.Get
-import Pulp.Args.Help
-import Pulp.Args.Types as Type
 import Pulp.Args.Parser (parse)
-import Pulp.System.FFI
-import Pulp.Outputter
+import Pulp.Args.Types as Type
+import Pulp.Browserify as Browserify
+import Pulp.Build as Build
+import Pulp.BumpVersion as BumpVersion
+import Pulp.Docs as Docs
+import Pulp.Init as Init
+import Pulp.Login as Login
+import Pulp.Project (getProject)
+import Pulp.Publish as Publish
+import Pulp.Repl as Repl
+import Pulp.Run as Run
+import Pulp.Server as Server
+import Pulp.Shell as Shell
+import Pulp.Test as Test
 import Pulp.Validate (validate)
 import Pulp.Version (printVersion)
-import Pulp.Project (getProject)
-
-import Pulp.Init as Init
-import Pulp.Build as Build
-import Pulp.Run as Run
-import Pulp.Test as Test
-import Pulp.Browserify as Browserify
-import Pulp.Docs as Docs
-import Pulp.Repl as Repl
-import Pulp.Server as Server
-import Pulp.Login as Login
-import Pulp.BumpVersion as BumpVersion
-import Pulp.Publish as Publish
 import Pulp.Watch as Watch
-import Pulp.Shell as Shell
+import Text.Parsing.Parser (parseErrorMessage)
 
 globals :: Array Args.Option
 globals = [
@@ -166,7 +165,11 @@ commands :: Array Args.Command
 commands = [
   Args.command "init" "Generate an example PureScript project." Nothing Init.action [
      Args.option "force" ["--force"] Type.flag
-       "Overwrite any project found in the current directory."
+       "Overwrite any project found in the current directory.",
+     Args.option "forceEff" ["--force-eff"] Type.flag
+       "Overwrite the detected compiler version and generate project using Eff.",
+     Args.option "forceEffect" ["--force-effect"] Type.flag
+       "Overwrite the detected compiler version and generate project using Effect."
      ],
   Args.command "build" "Build the project." remainderToPurs Build.action $
     buildArgs <> moduleArgs,
@@ -262,9 +265,9 @@ main = void $ runAff failed succeeded do
 runWithArgs :: Args.Args -> AffN Unit
 runWithArgs args = do
   out <- getOutputter args
-  _ <- validate out
+  ver <- validate out
   watch <- getFlag "watch" args.globalOpts
-  args' <- addProject args
+  args' <- addProject args >>= addInitFlags ver
   if watch && args.command.name /= "server"
     then
       Args.runAction Watch.action args'
@@ -289,6 +292,24 @@ runWithArgs args = do
         proj <- getProject as.globalOpts
         let globalOpts' = insert "_project" (Just (toForeign proj)) as.globalOpts
         pure $ as { globalOpts = globalOpts' }
+
+  version_0_12_0 = HVer.Version (fromFoldable [0, 12, 0]) Nil
+
+  addInitFlags ver as = do
+    if as.command.name == "init"
+      then do
+        hasForce <- disj <$> getFlag "forceEff" args.globalOpts <*> getFlag "forceEffect" args.globalOpts
+        if hasForce
+         then pure as
+         else do
+          let commandOpts' = insert (effectFlagForVersion ver) Nothing as.commandOpts
+          pure $ as { commandOpts = commandOpts' }
+      else pure as
+
+  effectFlagForVersion ver =
+    if ver < version_0_12_0
+      then "forceEff"
+      else "forceEffect"
 
   runShellForOption option opts out = do
     triggerCommand <- getOption option opts

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -296,12 +296,9 @@ runWithArgs args = do
   version_0_12_0 = HVer.Version (fromFoldable [0, 12, 0]) Nil
 
   addInitFlags ver as = do
-    if as.command.name == "init"
+    hasForce <- disj <$> getFlag "forceEff" args.globalOpts <*> getFlag "forceEffect" args.globalOpts
+    if as.command.name == "init" && not hasForce
       then do
-        hasForce <- disj <$> getFlag "forceEff" args.globalOpts <*> getFlag "forceEffect" args.globalOpts
-        if hasForce
-         then pure as
-         else do
           let commandOpts' = insert (effectFlagForVersion ver) Nothing as.commandOpts
           pure $ as { commandOpts = commandOpts' }
       else pure as

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -296,7 +296,7 @@ runWithArgs args = do
   version_0_12_0 = HVer.Version (fromFoldable [0, 12, 0]) Nil
 
   addInitFlags ver as = do
-    hasForce <- disj <$> getFlag "forceEff" args.globalOpts <*> getFlag "forceEffect" args.globalOpts
+    hasForce <- disj <$> getFlag "forceEff" args.commandOpts <*> getFlag "forceEffect" args.commandOpts
     if as.command.name == "init" && not hasForce
       then do
           let commandOpts' = insert (effectFlagForVersion ver) Nothing as.commandOpts

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -25,6 +25,8 @@ foreign import bowerFile :: String -> String
 
 data InitStyle = Bower | PscPackage
 
+data EffOrEffect = UseEff | UseEffect
+
 unlines :: Array String -> String
 unlines arr = joinWith "\n" arr <> "\n"
 
@@ -46,34 +48,58 @@ pursReplFile = unlines [
   "import Prelude"
   ]
 
-mainFile :: String
-mainFile = unlines [
-  "module Main where",
-  "",
-  "import Prelude",
-  "import Effect (Effect)",
-  "import Effect.Console (log)",
-  "",
-  "main :: Effect Unit",
-  "main = do",
-  "  log \"Hello sailor!\""
+mainFile :: EffOrEffect -> String
+mainFile = case _ of
+  UseEffect -> unlines [
+    "module Main where",
+    "",
+    "import Prelude",
+    "import Effect (Effect)",
+    "import Effect.Console (log)",
+    "",
+    "main :: Effect Unit",
+    "main = do",
+    "  log \"Hello sailor!\""
+    ]
+  UseEff -> unlines [
+    "module Main where",
+    "",
+    "import Prelude",
+    "import Control.Monad.Eff (Eff)",
+    "import Control.Monad.Eff.Console (CONSOLE, log)",
+    "",
+    "main :: forall e. Eff (console :: CONSOLE | e) Unit",
+    "main = do",
+    "  log \"Hello sailor!\""
   ]
 
-testFile :: String
-testFile = unlines [
-  "module Test.Main where",
-  "",
-  "import Prelude",
-  "import Effect (Effect)",
-  "import Effect.Console (log)",
-  "",
-  "main :: Effect Unit",
-  "main = do",
-  "  log \"You should add some tests.\""
+testFile :: EffOrEffect -> String
+testFile = case _ of
+  UseEffect -> unlines [
+    "module Test.Main where",
+    "",
+    "import Prelude",
+    "import Effect (Effect)",
+    "import Effect.Console (log)",
+    "",
+    "main :: Effect Unit",
+    "main = do",
+    "  log \"You should add some tests.\""
+    ]
+  UseEff -> unlines [
+    "module Test.Main where",
+    "",
+    "import Prelude",
+    "import Control.Monad.Eff (Eff)",
+    "import Control.Monad.Eff.Console (CONSOLE, log)",
+    "",
+    "main :: forall e. Eff (console :: CONSOLE | e) Unit",
+    "main = do",
+    "  log \"You should add some tests.\""
   ]
 
-projectFiles :: InitStyle -> String -> String -> Array { path :: String, content :: String }
-projectFiles initStyle pathRoot projectName =
+projectFiles :: InitStyle -> EffOrEffect -> String -> String -> Array { path :: String, content :: String }
+projectFiles initStyle effOrEffect pathRoot projectName =
   case initStyle of
     Bower      -> cons bowerJson common
     PscPackage -> common
@@ -82,17 +108,17 @@ projectFiles initStyle pathRoot projectName =
   bowerJson = { path: fullPath ["bower.json"],        content: bowerFile projectName }
   common  = [ { path: fullPath [".gitignore"],        content: gitignore }
             , { path: fullPath [".purs-repl"],        content: pursReplFile }
-            , { path: fullPath ["src", "Main.purs"],  content: mainFile }
-            , { path: fullPath ["test", "Main.purs"], content: testFile }
+            , { path: fullPath ["src", "Main.purs"],  content: mainFile effOrEffect }
+            , { path: fullPath ["test", "Main.purs"], content: testFile effOrEffect }
             ]
 
-init :: InitStyle -> Boolean -> Outputter -> AffN Unit
-init initStyle force out = do
+init :: InitStyle -> EffOrEffect -> Boolean -> Outputter -> AffN Unit
+init initStyle effOrEffect force out = do
   cwd <- liftEff Process.cwd
   let projectName = Path.basename cwd
   out.log $ "Generating project skeleton in " <> cwd
 
-  let files = projectFiles initStyle cwd projectName
+  let files = projectFiles initStyle effOrEffect cwd projectName
 
   when (not force) do
     for_ files \f -> do
@@ -122,7 +148,9 @@ init initStyle force out = do
 
 action :: Action
 action = Action \args -> do
-  force      <- getFlag "force" args.commandOpts
-  pscPackage <- getFlag "pscPackage" args.globalOpts
-  out        <- getOutputter args
-  init (if pscPackage then PscPackage else Bower) force out
+  force       <- getFlag "force" args.commandOpts
+  pscPackage  <- getFlag "pscPackage" args.globalOpts
+  forceEff    <- getFlag "forceEff" args.commandOpts
+  forceEffect <- getFlag "forceEffect" args.commandOpts
+  out         <- getOutputter args
+  init (if pscPackage then PscPackage else Bower) (if forceEff then UseEff else UseEffect) force out

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -133,14 +133,24 @@ init initStyle effOrEffect force out = do
     when (dir /= cwd) (mkdirIfNotExist dir)
     writeTextFile UTF8 f.path f.content
 
-  install initStyle
+  install initStyle effOrEffect
 
   where
-    install Bower = do
+    install Bower UseEff = do
+      launchBower ["install", "--save", "purescript-prelude", "purescript-console"]
+      launchBower ["install", "--save-dev", "purescript-psci-support"]
+
+    install Bower UseEffect = do
       launchBower ["install", "--save", "purescript-prelude", "purescript-console", "purescript-effect"]
       launchBower ["install", "--save-dev", "purescript-psci-support"]
 
-    install PscPackage = do
+    install PscPackage UseEff = do
+      launchPscPackage ["init"]
+      launchPscPackage ["install", "eff"]
+      launchPscPackage ["install", "console"]
+      launchPscPackage ["install", "psci-support"]
+
+    install PscPackage UseEffect = do
       launchPscPackage ["init"]
       launchPscPackage ["install", "effect"]
       launchPscPackage ["install", "console"]

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -141,8 +141,8 @@ init initStyle effOrEffect force out = do
 
   where
     install Bower UseEff = do
-      launchBower ["install", "--save", "purescript-prelude", "purescript-console"]
-      launchBower ["install", "--save-dev", "purescript-psci-support"]
+      launchBower ["install", "--save", "purescript-prelude@3.3.0", "purescript-console@3.0.0"]
+      launchBower ["install", "--save-dev", "purescript-psci-support@3.0.0"]
 
     install Bower UseEffect = do
       launchBower ["install", "--save", "purescript-prelude", "purescript-console", "purescript-effect"]

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -177,11 +177,11 @@ action = Action \args -> do
 
   minEffectVersion = HVer.Version (fromFoldable [0, 12, 0]) Nil
 
-  getEffOrEffect out withEff withEffect = do
-    if withEff
-      then pure UseEff
-      else if withEffect
-        then pure UseEffect
-         else do
-           ver <- getPursVersion out
-           if ver < minEffectVersion then pure UseEff else pure UseEffect
+  getEffOrEffect out withEff withEffect
+    | withEff    = pure UseEff
+    | withEffect = pure UseEffect
+    | otherwise  = do
+        ver <- getPursVersion out
+        if ver < minEffectVersion
+          then pure UseEff
+          else pure UseEffect

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -170,7 +170,7 @@ action = Action \args -> do
   effOrEffect <- getEffOrEffect out withEff withEffect
 
   if withEff && withEffect
-    then throw $ "Cannot specify both --with-eff and --with-effect. Please choose one and try again."
+    then throw "Cannot specify both --with-eff and --with-effect. Please choose one and try again."
     else init (if pscPackage then PscPackage else Bower) effOrEffect force out
 
   where

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -51,10 +51,10 @@ mainFile = unlines [
   "module Main where",
   "",
   "import Prelude",
-  "import Control.Monad.Eff (Eff)",
-  "import Control.Monad.Eff.Console (CONSOLE, log)",
+  "import Effect (Effect)",
+  "import Effect.Console (log)",
   "",
-  "main :: forall e. Eff (console :: CONSOLE | e) Unit",
+  "main :: Effect Unit",
   "main = do",
   "  log \"Hello sailor!\""
   ]
@@ -64,10 +64,10 @@ testFile = unlines [
   "module Test.Main where",
   "",
   "import Prelude",
-  "import Control.Monad.Eff (Eff)",
-  "import Control.Monad.Eff.Console (CONSOLE, log)",
+  "import Effect (Effect)",
+  "import Effect.Console (log)",
   "",
-  "main :: forall e. Eff (console :: CONSOLE | e) Unit",
+  "main :: Effect Unit",
   "main = do",
   "  log \"You should add some tests.\""
   ]
@@ -111,12 +111,12 @@ init initStyle force out = do
 
   where
     install Bower = do
-      launchBower ["install", "--save", "purescript-prelude", "purescript-console"]
+      launchBower ["install", "--save", "purescript-prelude", "purescript-console", "purescript-effect"]
       launchBower ["install", "--save-dev", "purescript-psci-support"]
 
     install PscPackage = do
       launchPscPackage ["init"]
-      launchPscPackage ["install", "eff"]
+      launchPscPackage ["install", "effect"]
       launchPscPackage ["install", "console"]
       launchPscPackage ["install", "psci-support"]
 

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -761,4 +761,9 @@ describe("integration tests", function() {
   it("exits 1 on invalid options", run(function*(sh, pulp) {
     yield pulp("build --blah", null, { expectedExitCode: 1 });
   }));
+
+  it("exits 1 on --with-eff and --with-effect", run(function*(sh, pulp, assert) {
+    yield pulp("init --with-eff --with-effect", null, { expectedExitCode: 1 });
+  }));
+
 });


### PR DESCRIPTION
Fixes #337

A few observations:
- once this is merged, there's no way to get an `Eff` project (I think that's okay)
- this won't work until the master branch of `prelude` and `console` are `0.12` (do we make a rc version of pulp as well?)
- `package-lock.json` was updated, should I add that too? I might be imagining things, but I'm sure I heard conversations about keeping it outside of repositories on Slack