### PR TITLE
Put executable names into a central list of constants

### DIFF
--- a/src/Pulp/BumpVersion.purs
+++ b/src/Pulp/BumpVersion.purs
@@ -21,6 +21,7 @@ import Pulp.Args
 import Pulp.Args.Get
 import Pulp.Git
 import Pulp.Publish (resolutionsFile)
+import Pulp.Constants as Constants
 
 action :: Action
 action = Action \args -> do
@@ -38,7 +39,7 @@ checkPursPublish :: Outputter -> AffN Unit
 checkPursPublish out = do
   out.log "Checking your package using purs publish..."
   resolutions <- resolutionsFile
-  exec "purs" ["publish", "--manifest", "bower.json", "--resolutions", resolutions, "--dry-run"] Nothing
+  exec Constants.pursPath ["publish", "--manifest", "bower.json", "--resolutions", resolutions, "--dry-run"] Nothing
 
 -- | Returns the new version that we should bump to.
 bumpVersion :: Args -> AffN Version
@@ -63,12 +64,12 @@ newVersion mbump mcurrent out = case mcurrent, mbump of
 tagNewVersion :: Version -> AffN Unit
 tagNewVersion version = do
   let versionStr = "v" <> Version.showVersion version
-  exec "git"
+  exec Constants.gitPath
     [ "commit"
     , "--allow-empty"
     , "--message=" <> versionStr
     ] Nothing
-  exec "git"
+  exec Constants.gitPath
     [ "tag"
     , "--annotate"
     , "--message=" <> versionStr

--- a/src/Pulp/Constants.purs
+++ b/src/Pulp/Constants.purs
@@ -1,0 +1,9 @@
+module Pulp.Constants where
+
+-- Paths to executables
+nodePath = "node" :: String
+bowerPath = "bower" :: String
+pursPath = "purs" :: String
+gitPath = "git" :: String
+pscPackagePath = "psc-package" :: String
+psaPath = "psa" :: String

--- a/src/Pulp/Docs.purs
+++ b/src/Pulp/Docs.purs
@@ -21,6 +21,7 @@ import Pulp.Exec
 import Pulp.Files
 import Pulp.Outputter
 import Pulp.System.FFI
+import Pulp.Constants as Constants
 
 action :: Action
 action = Action \args -> do
@@ -50,7 +51,7 @@ action = Action \args -> do
     for_ fails (out.log <<< ("  " <> _))
     out.err $ "This may be a bug."
 
-  _ <- execQuiet "purs" (["docs"] <> args.remainder <> sources globSrc <> docgen) Nothing
+  _ <- execQuiet Constants.pursPath (["docs"] <> args.remainder <> sources globSrc <> docgen) Nothing
 
   out.log "Documentation generated."
 

--- a/src/Pulp/Exec.purs
+++ b/src/Pulp/Exec.purs
@@ -29,12 +29,13 @@ import Unsafe.Coerce
 
 import Pulp.System.Stream
 import Pulp.System.FFI
+import Pulp.Constants as Constants
 
 psa :: Array String -> Array String -> Maybe (StrMap String) -> AffN Unit
-psa = compiler "psa"
+psa = compiler Constants.psaPath
 
 pursBuild :: Array String -> Array String -> Maybe (StrMap String) -> AffN Unit
-pursBuild deps args = compiler "purs" deps (["compile"] <> args)
+pursBuild deps args = compiler Constants.pursPath deps (["compile"] <> args)
 
 compiler :: String -> Array String -> Array String -> Maybe (StrMap String) -> AffN Unit
 compiler name deps args env =
@@ -50,7 +51,7 @@ compiler name deps args env =
 
 pursBundle :: Array String -> Array String -> Maybe (StrMap String) -> AffN String
 pursBundle files args env =
-  execQuiet "purs" (["bundle"] <> files <> args) env
+  execQuiet Constants.pursPath (["bundle"] <> files <> args) env
 
 -- | Start a child process asynchronously, with the given command line
 -- | arguments and environment, and wait for it to exit.

--- a/src/Pulp/Files.purs
+++ b/src/Pulp/Files.purs
@@ -28,6 +28,7 @@ import Pulp.Args
 import Pulp.Args.Get
 import Pulp.Exec (execQuiet)
 import Pulp.Project (usingPscPackage)
+import Pulp.Constants as Constants
 
 recursiveGlobWithExtension :: String -> Set String -> Array String
 recursiveGlobWithExtension ext =
@@ -65,7 +66,7 @@ dependencyGlobs opts = do
 
 pscPackageGlobs :: AffN (Set String)
 pscPackageGlobs =
-  execQuiet "psc-package" ["sources"] Nothing <#> processGlobs
+  execQuiet Constants.pscPackagePath ["sources"] Nothing <#> processGlobs
   where
     -- Split on newlines and strip the /**/*/.purs suffixes just to
     -- append them later so it plays well with the other globs

--- a/src/Pulp/Git.purs
+++ b/src/Pulp/Git.purs
@@ -21,11 +21,12 @@ import Node.ChildProcess as CP
 import Pulp.System.FFI
 import Pulp.Exec
 import Pulp.Utils (throw)
+import Pulp.Constants (gitPath)
 
 -- | Throw an error if the git working tree is dirty.
 requireCleanGitWorkingTree :: AffN Unit
 requireCleanGitWorkingTree = do
-  out <- execQuiet "git" ["status", "--porcelain"] Nothing
+  out <- execQuiet gitPath ["status", "--porcelain"] Nothing
   if Foldable.all String.null (String.split (String.Pattern "\n") out)
     then pure unit
     else throw ("Your git working tree is dirty. Please commit or stash " <>
@@ -39,7 +40,7 @@ requireCleanGitWorkingTree = do
 -- | version according to semver version comparison.
 getVersionFromGitTag :: AffN (Maybe (Tuple String Version))
 getVersionFromGitTag = do
-  output <- run "git" ["tag", "--points-at", "HEAD"]
+  output <- run gitPath ["tag", "--points-at", "HEAD"]
   pure (maxVersion output)
 
 -- | Get the latest semver version tag in the repository. The tag must start
@@ -49,7 +50,7 @@ getVersionFromGitTag = do
 -- | Returns Nothing if there are no such tags in the repository.
 getLatestTaggedVersion :: AffN (Maybe (Tuple String Version))
 getLatestTaggedVersion = do
-  output <- attempt $ run "git" ["describe", "--tags", "--abbrev=0", "HEAD"]
+  output <- attempt $ run gitPath ["describe", "--tags", "--abbrev=0", "HEAD"]
   pure $ either (const Nothing) maxVersion output
 
 -- | Run a command, piping stderr to /dev/null

--- a/src/Pulp/PackageManager.purs
+++ b/src/Pulp/PackageManager.purs
@@ -13,6 +13,7 @@ import Data.Maybe (Maybe(..))
 import Pulp.Exec (exec)
 import Pulp.System.FFI (AffN)
 import Pulp.System.Which (which)
+import Pulp.Constants as Constants
 
 run :: String -> String -> Array String -> AffN Unit
 run execName errorMsg args = do
@@ -24,11 +25,11 @@ run execName errorMsg args = do
   where errorMsg' = "No `" <> execName <> "` executable found.\n\n" <> errorMsg
 
 launchBower :: Array String -> AffN Unit
-launchBower = run "bower" """Pulp no longer bundles Bower. You'll need to install it manually:
+launchBower = run Constants.bowerPath """Pulp no longer bundles Bower. You'll need to install it manually:
 
    $ npm install -g bower
 """
 
 launchPscPackage :: Array String -> AffN Unit
 launchPscPackage = do
-  run "psc-package" "Install psc-package from: https://github.com/purescript/psc-package"
+  run Constants.pscPackagePath "Install psc-package from: https://github.com/purescript/psc-package"

--- a/src/Pulp/Repl.purs
+++ b/src/Pulp/Repl.purs
@@ -8,10 +8,11 @@ import Data.Set as Set
 import Pulp.Args
 import Pulp.Exec
 import Pulp.Files
+import Pulp.Constants as Constants
 
 action :: Action
 action = Action \args -> do
   let opts = Map.union args.globalOpts args.commandOpts
   globs <- Set.union <$> defaultGlobs opts
                      <*> testGlobs opts
-  execInteractive "purs" (["repl"] <> sources globs <> args.remainder) Nothing
+  execInteractive Constants.pursPath (["repl"] <> sources globs <> args.remainder) Nothing

--- a/src/Pulp/Test.purs
+++ b/src/Pulp/Test.purs
@@ -19,6 +19,7 @@ import Pulp.Exec (exec)
 import Pulp.Build as Build
 import Pulp.Run (setupEnv, makeEntry)
 import Pulp.System.Files (openTemp)
+import Pulp.Constants as Constants
 
 action :: Action
 action = Action \args -> do
@@ -27,6 +28,8 @@ action = Action \args -> do
 
   runtime <- getOption' "runtime" opts
   let isNode = runtime == "node"
+  let runtimeExecutable =
+        if isNode then Constants.nodePath else runtime
   let changeOpts = if isNode
                      then id :: Options -> Options -- helps type inference
                      else Map.insert "to" (Just (toForeign "./output/test.js"))
@@ -50,7 +53,7 @@ action = Action \args -> do
       src <- liftEff $ Buffer.fromString (makeEntry main) UTF8
       _ <- FS.fdAppend info.fd src
       _ <- FS.fdClose info.fd
-      exec runtime
+      exec runtimeExecutable
            ([info.path] <> args.remainder)
            (Just env)
     else do

--- a/src/Pulp/Validate.purs
+++ b/src/Pulp/Validate.purs
@@ -17,6 +17,7 @@ import Text.Parsing.Parser (parseErrorMessage)
 import Pulp.Exec (execQuiet)
 import Pulp.System.FFI
 import Pulp.Outputter (Outputter())
+import Pulp.Constants as Constants
 
 validate :: Outputter -> AffN Version
 validate out = do
@@ -31,13 +32,13 @@ validate out = do
   pure ver
 
 getPursVersion :: Outputter -> AffN Version
-getPursVersion = getVersionFrom "purs"
+getPursVersion = getVersionFrom Constants.pursPath
 
 minimumPursVersion :: Version
 minimumPursVersion = Version (fromFoldable [0, 11, 0]) Nil
 
 getPsaVersion :: Outputter -> AffN Version
-getPsaVersion = getVersionFrom "psa"
+getPsaVersion = getVersionFrom Constants.psaPath
 
 getVersionFrom :: String -> Outputter -> AffN Version
 getVersionFrom bin out = do

--- a/src/Pulp/Version.purs
+++ b/src/Pulp/Version.purs
@@ -24,6 +24,7 @@ import Node.Globals (__dirname)
 import Pulp.System.FFI (AffN)
 import Pulp.System.Which (which)
 import Pulp.Exec (execQuiet)
+import Pulp.Constants as Constants
 
 version :: Version
 version =
@@ -44,9 +45,11 @@ versionString =
 
 printVersion :: AffN Unit
 printVersion = do
-  pursVersion <- execQuiet "purs" ["--version"] Nothing
-  pursPath <- attempt $ which "purs"
+  pursVersion <- execQuiet Constants.pursPath ["--version"] Nothing
+  pursPath' <- if Path.isAbsolute Constants.pursPath
+              then pure $ Right Constants.pursPath
+              else attempt $ which "purs"
   liftEff $ Console.log $
     "Pulp version " <> showVersion version <>
     "\npurs version " <> trim pursVersion <>
-    either (const "") (\p -> " using " <> trim p) pursPath
+    either (const "") (\p -> " using " <> trim p) pursPath'


### PR DESCRIPTION
This way there is one place where the paths of required external tools can be
changed at compile time (e.g. to patch in absolute paths for nix).

This is a rather large patch because pulp calls to external tools in a lot of places. Some interesting changes are in `Test.purs` and `Version.purs`.

This is part of an ongoing effort to package all Purescript tooling for `nixpkgs` in a nice way.