### PR TITLE
Generate new resolutions format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "purescript-avar": "^3.0.0",
     "purescript-versions": "^5.0.0",
     "purescript-foreign-generic": "^7.0.0",
-    "purescript-ansi": "^5.0.0"
+    "purescript-ansi": "^5.0.0",
+    "purescript-simple-json": "^4.4.1"
   },
   "devDependencies": {
     "purescript-assert": "^4.0.0"


### PR DESCRIPTION
Fixes #351. Generate the simpler resolutions format expected by the
compiler (as of the next release). If the compiler version being used is
not new enough to use the new format, we use `bower list --offline
--json` as before.