### PR TITLE
Pass follow: true to gaze to follow symlinked directories

### DIFF
--- a/src/Pulp/Watch.js
+++ b/src/Pulp/Watch.js
@@ -7,7 +7,7 @@ exports.watch = function(pattern) {
     return function() {
       var Gaze = require("gaze").Gaze;
 
-      var gaze = new Gaze(pattern);
+      var gaze = new Gaze(pattern, { follow: true });
 
       gaze.on("all", function(_, path) {
         act(path)();


### PR DESCRIPTION
A follow up to #371. Fix the case when I have a shared folder like
```
sym
├── A.purs
├── B
│   └── B.purs
```
After `cd src && ln -s ../../sym .` and `pulp -w build` will only watch for `sym/A.purs` but not `sym/B/B.purs`.

The reason is gaze uses [globule](https://www.npmjs.com/package/globule), which uses [glob](https://www.npmjs.com/package/glob). The readme of glob says
> `**` ... ... does not crawl symlinked directories.

> ### Options
> `follow` Follow symlinked directories when expanding `**` patterns. Note that this can result in a lot of duplicate references in the presence of cyclic links.