### PR TITLE
Use stream api of nodejs, remove string-stream package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3391,11 +3391,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "string-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/string-stream/-/string-stream-0.0.7.tgz",
-      "integrity": "sha1-z83oJ5n6YvMDQpqqeTNu6INDMv4="
-    },
     "string_decoder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "node-static": "^0.7.11",
     "read": "^1.0.7",
     "sorcery": "^0.10.0",
-    "string-stream": "0.0.7",
     "temp": "^0.9.0",
     "through": "^2.3.8",
     "tree-kill": "^1.2.1",

--- a/src/Pulp/Browserify.js
+++ b/src/Pulp/Browserify.js
@@ -10,13 +10,15 @@ function write(input, output, callback) {
 }
 
 exports["browserifyBundle'"] = function browserifyBundle$prime(opts, callback) {
-  var StringStream = require("string-stream");
+  var stream = new require("stream").Readable();
   var browserify = require("browserify");
   var mold = require("mold-source-map");
   var path = require("path");
+  stream.push(opts.src);
+  stream.push(null);
   var b = browserify({
     basedir: opts.basedir,
-    entries: new StringStream(opts.src),
+    entries: stream,
     standalone: opts.standalone,
     debug: opts.debug
   });


### PR DESCRIPTION
Somehow [string-stream](https://www.npmjs.com/package/string-stream) doesn't work with nodejs 12, after all it's a very old package last published 6 years ago.

This PR changes to use the [stream api](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_readable_push_chunk_encoding) of nodejs directly, found it at https://stackoverflow.com/a/36042506