### PR TITLE
Updates for purs v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Pulp Release History
 
+## Unreleased changes
+
+* Remove the `--with-dependencies` option in `pulp docs`; now that html is the
+  default output format of `purs docs`, it makes less sense to only produce
+  local modules by default (since if we don't produce dependency modules then
+  links will be broken). To restore the previous behaviour, you will need to
+  run `pulp docs -- --format markdown`, and then manually delete non-local
+  modules from the `generated-docs/md` directory.
+* Add a --build-path argument for `pulp docs`; to be passed to `purs docs` for
+  `purs >= 0.13.0`, since `purs docs` now uses a compiler output directory.
+
 ## 12.4.2
 
 * Fix `pulp version` and `pulp publish`, which were both completely broken as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+* Changes to support `purs >= 0.13.0` in `pulp docs`. Because of idiosyncrasies
+  in the previous `purs docs` CLI, it has not been possible to support both,
+  so support for `purs < 0.13.0` in `pulp docs` has been dropped.
 * Remove the `--with-dependencies` option in `pulp docs`; now that html is the
   default output format of `purs docs`, it makes less sense to only produce
   local modules by default (since if we don't produce dependency modules then

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1,13 +1,6 @@
 module Main where
 
-import Effect.Aff
-import Effect.Class
-import Effect.Exception
 import Prelude
-import Pulp.Args.Get
-import Pulp.Args.Help
-import Pulp.Outputter
-import Pulp.System.FFI
 
 import Control.Monad.Except (runExcept)
 import Data.Array (head, drop)
@@ -19,7 +12,10 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (stripPrefix, Pattern(..))
 import Data.Version (Version, version, showVersion, parseVersion)
 import Effect (Effect)
+import Effect.Aff (Aff, attempt, runAff, throwError)
+import Effect.Class (liftEffect)
 import Effect.Console as Console
+import Effect.Exception (Error, catchException, error, message, throwException)
 import Effect.Unsafe (unsafePerformEffect)
 import Foreign (Foreign, unsafeToForeign, readString)
 import Foreign.Index (readProp)
@@ -29,6 +25,8 @@ import Node.FS.Sync (readTextFile)
 import Node.Path as Path
 import Node.Process as Process
 import Pulp.Args as Args
+import Pulp.Args.Get (getFlag, getOption)
+import Pulp.Args.Help (printCommandHelp, printHelp)
 import Pulp.Args.Parser (parse)
 import Pulp.Args.Types as Type
 import Pulp.Browserify as Browserify
@@ -37,12 +35,14 @@ import Pulp.BumpVersion as BumpVersion
 import Pulp.Docs as Docs
 import Pulp.Init as Init
 import Pulp.Login as Login
+import Pulp.Outputter (getOutputter, makeOutputter)
 import Pulp.Project (getProject)
 import Pulp.Publish as Publish
 import Pulp.Repl as Repl
 import Pulp.Run as Run
 import Pulp.Server as Server
 import Pulp.Shell as Shell
+import Pulp.System.FFI (unsafeInspect)
 import Pulp.Test as Test
 import Pulp.Validate (validate)
 import Pulp.Version (printVersion)
@@ -97,11 +97,15 @@ pathArgs = [
   dependencyPathOption
   ]
 
+buildPath :: Args.Option
+buildPath =
+  Args.optionDefault "buildPath" ["--build-path", "-o"] Type.string
+    "Path for compiler output." "./output"
+
 -- | Options common to 'build', 'test', and 'browserify'
 buildishArgs :: Array Args.Option
 buildishArgs = [
-  Args.optionDefault "buildPath" ["--build-path", "-o"] Type.string
-    "Path for compiler output." "./output",
+  buildPath,
   Args.option "noPsa" ["--no-psa"] Type.flag
     "Do not attempt to use the psa frontend instead of purs compile",
   Args.option "noCheckMain" ["--no-check-main"] Type.flag
@@ -198,6 +202,7 @@ commands = [
       "Run the program using this command instead of Node." "node"
     ] <> runArgs,
   Args.command "docs" "Generate project documentation." remainderToDocs Docs.action $ [
+    buildPath,
     Args.option "withTests" ["--with-tests", "-t"] Type.flag
       "Include tests.",
     Args.option "withDependencies" ["--with-dependencies", "-d"] Type.flag

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -204,9 +204,7 @@ commands = [
   Args.command "docs" "Generate project documentation." remainderToDocs Docs.action $ [
     buildPath,
     Args.option "withTests" ["--with-tests", "-t"] Type.flag
-      "Include tests.",
-    Args.option "withDependencies" ["--with-dependencies", "-d"] Type.flag
-      "Include external dependencies."
+      "Include tests."
     ] <> pathArgs,
   Args.commandWithAlias "repl"
     "Launch a PureScript REPL configured for the project." remainderToRepl

--- a/src/Pulp/Docs.purs
+++ b/src/Pulp/Docs.purs
@@ -32,14 +32,11 @@ action = Action \args -> do
   globInputFiles <- Set.union <$> includeWhen withTests (testGlobs opts)
                               <*> defaultGlobs opts
 
-  buildPathArgs <-
-    if pursVersion >= Version (fromFoldable [0,13,0]) Nil
-      then do
-        buildPath <- getOption' "buildPath" opts
-        pure ["--compile-output", buildPath]
-      else
-        pure []
+  buildPath <- getOption' "buildPath" opts
 
-  exec "purs" (["docs"] <> buildPathArgs <> args.remainder <> sources globInputFiles) Nothing
+  when (pursVersion < Version (fromFoldable [0,13,0]) Nil)
+    (out.log "Warning: 'pulp docs' now only supports 'purs' v0.13.0 and above. Please either update 'purs' or downgrade 'pulp'.")
+
+  exec "purs" (["docs", "--compile-output", buildPath] <> args.remainder <> sources globInputFiles) Nothing
 
   out.log "Documentation generated."

--- a/src/Pulp/Docs.purs
+++ b/src/Pulp/Docs.purs
@@ -33,7 +33,7 @@ action = Action \args -> do
                               <*> defaultGlobs opts
 
   buildPathArgs <-
-    if true --(pursVersion >= Version (fromFoldable [0,13,0]) Nil) do
+    if pursVersion >= Version (fromFoldable [0,13,0]) Nil
       then do
         buildPath <- getOption' "buildPath" opts
         pure ["--compile-output", buildPath]

--- a/src/Pulp/Docs.purs
+++ b/src/Pulp/Docs.purs
@@ -2,29 +2,25 @@
 module Pulp.Docs where
 
 import Prelude
-import Pulp.Args
-import Pulp.Args.Get
-import Pulp.Exec
-import Pulp.Files
-import Pulp.Outputter
 
-import Data.Array as Array
-import Data.Foldable (fold, for_, elem)
+import Data.List (List(..), fromFoldable)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Set as Set
-import Data.String as String
-import Data.Traversable (traverse)
-import Data.Tuple (Tuple(..))
-import Effect.Aff (Aff)
+import Data.Version.Haskell (Version(..))
 import Effect.Class (liftEffect)
-import Node.Encoding (Encoding(..))
-import Node.FS.Aff as FS
 import Node.Process as Process
+import Pulp.Args (Action(..))
+import Pulp.Args.Get (getFlag, getOption')
+import Pulp.Exec (exec)
+import Pulp.Files (defaultGlobs, sources, testGlobs)
+import Pulp.Outputter (getOutputter)
+import Pulp.Validate (getPursVersion)
 
 action :: Action
 action = Action \args -> do
   out <- getOutputter args
+  pursVersion <- getPursVersion out
 
   cwd <- liftEffect Process.cwd
   out.log $ "Generating documentation in " <> cwd
@@ -32,63 +28,18 @@ action = Action \args -> do
   let opts = Map.union args.globalOpts args.commandOpts
 
   withTests <- getFlag "withTests" opts
-  withDeps <- getFlag "withDependencies" opts
-
   let includeWhen b act = if b then act else pure Set.empty
-  optionalExtras <- Set.union <$> includeWhen withTests (testGlobs opts)
-                              <*> includeWhen withDeps  (dependencyGlobs opts)
+  globInputFiles <- Set.union <$> includeWhen withTests (testGlobs opts)
+                              <*> defaultGlobs opts
 
-  globSrc <- Set.union optionalExtras <$> defaultGlobs opts
-  globGen <- Set.union optionalExtras <$> localGlobs opts
+  buildPathArgs <-
+    if true --(pursVersion >= Version (fromFoldable [0,13,0]) Nil) do
+      then do
+        buildPath <- getOption' "buildPath" opts
+        pure ["--compile-output", buildPath]
+      else
+        pure []
 
-  genFiles <- resolveGlobs (sources globGen)
-
-  Tuple docgen fails <- fold <$> traverse makeDocgen genFiles
-
-  unless (Array.null fails) $ do
-    out.err $ "Unable to extract module name from the following modules:"
-    for_ fails (out.log <<< ("  " <> _))
-    out.err $ "This may be a bug."
-
-  _ <- execQuiet "purs" (["docs"] <> args.remainder <> sources globSrc <> docgen) Nothing
+  exec "purs" (["docs"] <> buildPathArgs <> args.remainder <> sources globInputFiles) Nothing
 
   out.log "Documentation generated."
-
--- | Given a file path to be included in the documentation, return a --docgen
--- | argument for it, to be passed to `purs docs`.
-makeDocgen :: String -> Aff (Tuple (Array String) (Array String))
-makeDocgen path = do
-  maybeModName <- extractModuleName path
-  pure $ case maybeModName of
-    Just mn ->
-      Tuple ["--docgen", showModuleName mn <> ":" <> docPath mn] []
-    Nothing ->
-      Tuple [] [path]
-
--- | Given a module name, return the file path where its documentation should
--- | be written to.
-docPath :: ModuleName -> String
-docPath mn = "generated-docs/" <> String.joinWith "/" mn <> ".md"
-
-type ModuleName = Array String
-
-showModuleName :: ModuleName -> String
-showModuleName = String.joinWith "."
-
--- | Given a PureScript source file path, extract its module name (or throw
--- | an error).
-extractModuleName :: String -> Aff (Maybe ModuleName)
-extractModuleName path = go <$> FS.readTextFile UTF8 path
-  where
-  go = String.split (String.Pattern "\n")
-        >>> map moduleNameFromLine
-        >>> Array.catMaybes
-        >>> Array.head
-
--- | Given a line in a PureScript source file, attempt to extract its name.
-moduleNameFromLine :: String -> Maybe ModuleName
-moduleNameFromLine =
-  String.stripPrefix (String.Pattern "module ")
-  >>> map (   String.takeWhile (not <<< (_ `elem` String.codePointFromChar <$> [' ', '(']))
-          >>> String.split (String.Pattern ".")
-          )

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -8,12 +8,9 @@ import which from "which";
 
 const hello = "Hello sailor!";
 const test = "You should add some tests.";
-const docLine1 = "## Module Main";
 const bowerMissing = "* ERROR: No bower.json or psc-package.json found in current or parent directories. Are you in a PureScript project?";
 const initWithoutForce = f => new RegExp('\\* ERROR: Found .*'+f+': There\'s already a project here. Run `pulp init --force` if you\'re sure you want to overwrite it.');
 const filesToOverwrite = ['./bower.json', './.gitignore', 'src/Main.purs', 'test/Main.purs'];
-const testDocLine1 = "## Module Test.Main";
-const consoleDocLine1 = "## Module Effect.Console";
 const buildHelp = ["Command: build", "Build the project."];
 const docsHelp = ["Command: docs", "Generate project documentation."];
 const skipped = "* Project unchanged; skipping build step.";
@@ -548,29 +545,25 @@ describe("integration tests", function() {
   it("pulp docs", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("docs");
-    assert.file("generated-docs/Main.md", (c) =>
-      assert.equal(c.split(newlines)[0], docLine1));
+    assert.file("generated-docs/html/Main.html");
   }));
 
   it("pulp docs --with-tests", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("docs --with-tests");
-    assert.file("generated-docs/Test/Main.md", (c) =>
-      assert.equal(c.split(newlines)[0], testDocLine1));
+    assert.file("generated-docs/html/Test.Main.html");
   }));
 
   it("pulp docs --with-dependencies", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("docs --with-dependencies");
-    assert.file("generated-docs/Effect/Console.md", (c) =>
-      assert.equal(c.split(newlines)[0], consoleDocLine1));
+    assert.file("generated-docs/html/Effect.Console.html");
   }));
 
   it("pulp docs --with-dependencies with psc-package", run(function*(sh, pulp, assert) {
     yield pulp("--psc-package init");
     yield pulp("docs --with-dependencies");
-    assert.file("generated-docs/Effect/Console.md", (c) =>
-      assert.equal(c.split(newlines)[0], consoleDocLine1));
+    assert.file("generated-docs/html/Effect.Console.html");
   }));
 
   it("pulp psci includes dependencies", run(function*(sh, pulp, assert) {

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -120,6 +120,15 @@ function* createModule(sh, temp, name) {
   return path.join("output", name, "index.js");
 }
 
+const getPursVersion = co.wrap(function*(sh, assert) {
+  const [out] = yield sh("purs --version");
+  const pursVer = semver.parse(out.split(/\s/)[0]);
+  if (pursVer == null) {
+    assert.fail("Unable to parse output of purs --version");
+  }
+  return pursVer;
+});
+
 describe("integration tests", function() {
   // This is, unfortunately, required, as CI is horrendously slow.
   this.timeout(90000);
@@ -545,13 +554,19 @@ describe("integration tests", function() {
   it("pulp docs", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("docs");
-    assert.file("generated-docs/html/Main.html");
+    const pursVer = yield getPursVersion(sh, assert);
+    if (semver.gte(pursVer, semver.parse('0.13.0'))) {
+      assert.file("generated-docs/html/Main.html");
+    }
   }));
 
   it("pulp docs --with-tests", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("docs --with-tests");
-    assert.file("generated-docs/html/Test.Main.html");
+    const pursVer = yield getPursVersion(sh, assert);
+    if (semver.gte(pursVer, semver.parse('0.13.0'))) {
+      assert.file("generated-docs/html/Test.Main.html");
+    }
   }));
 
   it("pulp psci includes dependencies", run(function*(sh, pulp, assert) {

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -552,19 +552,19 @@ describe("integration tests", function() {
   }));
 
   it("pulp docs", run(function*(sh, pulp, assert) {
-    yield pulp("init");
-    yield pulp("docs");
     const pursVer = yield getPursVersion(sh, assert);
     if (semver.gte(pursVer, semver.parse('0.13.0'))) {
+      yield pulp("init");
+      yield pulp("docs");
       assert.file("generated-docs/html/Main.html");
     }
   }));
 
   it("pulp docs --with-tests", run(function*(sh, pulp, assert) {
-    yield pulp("init");
-    yield pulp("docs --with-tests");
     const pursVer = yield getPursVersion(sh, assert);
     if (semver.gte(pursVer, semver.parse('0.13.0'))) {
+      yield pulp("init");
+      yield pulp("docs --with-tests");
       assert.file("generated-docs/html/Test.Main.html");
     }
   }));

--- a/test-js/integration.js
+++ b/test-js/integration.js
@@ -554,18 +554,6 @@ describe("integration tests", function() {
     assert.file("generated-docs/html/Test.Main.html");
   }));
 
-  it("pulp docs --with-dependencies", run(function*(sh, pulp, assert) {
-    yield pulp("init");
-    yield pulp("docs --with-dependencies");
-    assert.file("generated-docs/html/Effect.Console.html");
-  }));
-
-  it("pulp docs --with-dependencies with psc-package", run(function*(sh, pulp, assert) {
-    yield pulp("--psc-package init");
-    yield pulp("docs --with-dependencies");
-    assert.file("generated-docs/html/Effect.Console.html");
-  }));
-
   it("pulp psci includes dependencies", run(function*(sh, pulp, assert) {
     yield pulp("init");
     yield pulp("psci");

--- a/test-js/sh.js
+++ b/test-js/sh.js
@@ -40,7 +40,7 @@ function sh(cwd, cmd, input, opts) {
 function asserts(path) {
   const file = (filename, pred) => {
     const data = fs.readFileSync(resolve(path, filename), "utf-8");
-    pred(data);
+    pred ? pred(data) : true;
   };
 
   const exists = (filename) => file(filename, (data) => true);


### PR DESCRIPTION
* Remove `--with-dependencies` argument to `pulp docs`
* Stop using `--docgen` argument when generating docs.