### PR TITLE
Allow passing node option to browserify

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -195,7 +195,9 @@ commands = [
       Args.option "standalone" ["--standalone"] Type.string
         "Output a UMD bundle with the given external module name.",
       Args.option "skipCompile" ["--skip-compile"] Type.flag
-        "Assume PureScript code has already been compiled. Useful for when you want to pass options to purs."
+        "Assume PureScript code has already been compiled. Useful for when you want to pass options to purs.",
+      Args.option "node" ["--node"] Type.flag
+        "Output a bundle optimized to be run with node."
       ] <> buildArgs,
   Args.command "run" "Compile and run the project." remainderToProgram Run.action $ [
     Args.optionDefault "runtime" ["--runtime", "-r"] Type.string

--- a/src/Pulp/Browserify.js
+++ b/src/Pulp/Browserify.js
@@ -19,6 +19,7 @@ exports["browserifyBundle'"] = function browserifyBundle$prime(opts, callback) {
   var b = browserify({
     basedir: opts.basedir,
     entries: stream,
+    node: opts.node,
     standalone: opts.standalone,
     debug: opts.debug
   });
@@ -47,6 +48,7 @@ exports["browserifyIncBundle'"] = function browserifyIncBundle$prime(opts, callb
   var b = browserifyInc({
     basedir: opts.buildPath,
     cacheFile: opts.cachePath,
+    node: opts.node,
     standalone: opts.standalone,
     debug: opts.debug
   });

--- a/src/Pulp/Browserify.purs
+++ b/src/Pulp/Browserify.purs
@@ -85,6 +85,7 @@ optimising = Action \args -> do
   globs     <- defaultGlobs opts
   buildPath <- getOption' "buildPath" opts
   main      <- getOption' "main" opts
+  node      <- getFlag "node" opts
   transform <- getOption "transform" opts
   standalone <- getOption "standalone" opts
   sourceMaps <- getFlag "sourceMaps" opts
@@ -125,6 +126,7 @@ optimising = Action \args -> do
       , src: bundledJs <> if isJust standalone then makeOptExport main else ""
       , transform: toNullable transform
       , standalone: toNullable standalone
+      , node: node
       , out: out'
       , debug: sourceMaps
       , outDir
@@ -156,6 +158,7 @@ incremental = Action \args -> do
   transform <- getOption "transform" opts
   standalone <- getOption "standalone" opts
   main <- getOption' "main" opts
+  node <- getFlag "node" opts
   sourceMaps <- getFlag "sourceMaps" opts
 
   unlessM (shouldSkipMainCheck opts)
@@ -180,6 +183,7 @@ incremental = Action \args -> do
       , path: path
       , transform: toNullable transform
       , standalone: toNullable standalone
+      , node: node
       , out: out'
       , debug: sourceMaps
       , outDir
@@ -204,6 +208,7 @@ type BrowserifyOptions =
   , src        :: String
   , transform  :: Nullable String
   , standalone :: Nullable String
+  , node       :: Boolean
   , out        :: WritableStream
   , debug      :: Boolean
   , outDir     :: String
@@ -223,6 +228,7 @@ type BrowserifyIncOptions =
   , path       :: String
   , transform  :: Nullable String
   , standalone :: Nullable String
+  , node       :: Boolean
   , out        :: WritableStream
   , debug      :: Boolean
   , outDir     :: String


### PR DESCRIPTION
This PR allows passing the `node` option to `pulp browserify`. This is useful when building a bundle for running on node.

I was unsure about the testing strategy for new features as the integration suite does not seem comprehensive for the `browserify` command.