### PR TITLE
Add debug flag; include devDeps when publishing; misc other changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "16.0.0-0",
+  "version": "16.0.0-1",
   "description": "A build system for PureScript projects",
   "keywords": [
     "purescript",

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -54,6 +54,8 @@ globals = [
     "Read this bower.json file instead of autodetecting it.",
   Args.option "pscPackage" ["--psc-package"] Type.flag
     "Use psc-package for package management.",
+  Args.option "debug" ["--debug"] Type.flag
+    "Enable debug logging",
   Args.option "watch" ["--watch", "-w"] Type.flag
     "Watch source directories and re-run command if something changes.",
   Args.option "monochrome" ["--monochrome"] Type.flag
@@ -262,7 +264,7 @@ main = void $ runAff (either failed succeeded) do
     printHelp out globals commands
     liftEffect $ Process.exit 1
 
-  out = makeOutputter false
+  out = makeOutputter false false
 
 runWithArgs :: Args.Args -> Aff Unit
 runWithArgs args = do
@@ -312,7 +314,7 @@ requireNodeAtLeast minimum = do
 
 argsParserDiagnostics :: Args.Args -> Aff Unit
 argsParserDiagnostics opts = do
-  let out = makeOutputter false
+  let out = makeOutputter false true
   out.log $ "Globals: " <> show ((map <<< map) showForeign opts.globalOpts)
   out.log $ "Command: " <> opts.command.name
   out.log $ "Locals: " <> show ((map <<< map) showForeign opts.commandOpts)

--- a/src/Pulp/Init.purs
+++ b/src/Pulp/Init.purs
@@ -174,10 +174,10 @@ init initStyle effOrEffect force out = do
 
     getDepsVersions v
       | v >= psVersions.v0_15_0 =
-          { prelude: "purescript-prelude@master"
-          , console: "purescript-console@master"
-          , effect: "purescript-effect@master"
-          , psciSupport: "purescript-psci-support@master"
+          { prelude: "purescript-prelude@v6.0.0"
+          , console: "purescript-console@v6.0.0"
+          , effect: "purescript-effect@v4.0.0"
+          , psciSupport: "purescript-psci-support@v6.0.0"
           }
       | v >= psVersions.v0_14_0 =
           { prelude: "purescript-prelude@v5.0.1"

--- a/src/Pulp/Publish.purs
+++ b/src/Pulp/Publish.purs
@@ -54,19 +54,17 @@ action = Action \args -> do
 
   out.debug "Checking clean git working tree"
   requireCleanGitWorkingTree
-  out.debug "getting auth token"
+  out.debug "Getting auth token"
   authToken <- readTokenFile
-  out.debug "parsing bower.json file"
+  out.debug "Parsing bower.json file"
   manifest :: BowerJson <- parseJsonFile "bower.json"
-  out.debug $ show manifest
+  out.debug $ "Parsed manifest:\n" <> show manifest
 
-  out.debug "getting resolutions file"
+  out.debug "Getting resolutions file..."
   resolutionsPath <- resolutionsFile manifest args
-  out.debug "pursPublish >>= gzip"
   out.debug =<< readTextFile UTF8 resolutionsPath
-  out.debug "pursPublish"
+  out.debug "Calling purs publish..."
   res <- pursPublish resolutionsPath
-  out.debug "gzip"
   gzippedJson <- gzip res
 
   out.debug "Getting repo url"

--- a/src/Pulp/Publish.purs
+++ b/src/Pulp/Publish.purs
@@ -330,6 +330,7 @@ uploadPursuitDocs out authToken gzippedJson = do
       pure unit
     other -> do
       out.err =<< concatStream (HTTP.responseAsStream res)
+      out.err $ HTTP.statusMessage res
       throw ("Expected an HTTP 201 response from Pursuit, got: " <> show other)
 
   where

--- a/src/Pulp/Publish.purs
+++ b/src/Pulp/Publish.purs
@@ -62,10 +62,9 @@ action = Action \args -> do
 
   out.debug "Getting resolutions file..."
   resolutionsPath <- resolutionsFile manifest args
-  out.debug =<< readTextFile UTF8 resolutionsPath
-  out.debug "Calling purs publish..."
-  res <- pursPublish resolutionsPath
-  gzippedJson <- gzip res
+  content <- readTextFile UTF8 resolutionsPath
+  out.debug $ "Resolutions file:\n" <> content
+  gzippedJson <- pursPublish resolutionsPath >>= gzip
 
   out.debug "Getting repo url"
   repoUrl <- map _.url manifest.repository # orErr "'repository' key not present in bower.json"


### PR DESCRIPTION
While publishing `arraybuffer-types`, we discovered that `pulp publish` would fail because it would not consider the `devDependencies` in the `bower.json` file when producing the resolutions format needed for `purs publish`. Since `purs publish` does expect this data, the publish would fail.

I don't think `purs publish` is correct in this regard, but it's been like that for the past 7 years and this at least unblocks the library release work.

To get tests to pass, we also need to install the correct versions of `console`, `effect`, `console`, etc. So, these were also updated.

While we're making changes, we'll also output the message in the error when `pulp publish` fails.

I also bumped the version so that we can install this one as opposed to `16.0.0-0`, so that we can release this on npm.